### PR TITLE
fix up factory for use in service

### DIFF
--- a/src/thor/autocost.cc
+++ b/src/thor/autocost.cc
@@ -2,11 +2,82 @@
 
 #include <iostream>
 #include <valhalla/midgard/constants.h>
+#include <valhalla/baldr/directededge.h>
+#include <valhalla/baldr/nodeinfo.h>
 
 using namespace valhalla::baldr;
 
 namespace valhalla {
 namespace thor {
+
+/**
+ * Derived class providing dynamic edge costing for pedestrian routes.
+ */
+class AutoCost : public DynamicCost {
+ public:
+  AutoCost();
+
+  virtual ~AutoCost();
+
+  /**
+   * Checks if access is allowed for the provided directed edge.
+   * This is generally based on mode of travel and the access modes
+   * allowed on the edge. However, it can be extended to exclude access
+   * based on other parameters.
+   * @param edge      Pointer to a directed edge.
+   * @param uturn     Is this a Uturn?
+   * @param dist2dest Distance to the destination.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+                       const float dist2dest) const;
+
+  /**
+   * Checks if access is allowed for the provided node. Node access can
+   * be restricted if bollards or gates are present. (TODO - others?)
+   * @param  edge  Pointer to node information.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::NodeInfo* node) const;
+
+  /**
+   * Get the cost given a directed edge.
+   * @param edge  Pointer to a directed edge.
+   * @return  Returns the cost to traverse the edge.
+   */
+  virtual float Get(const baldr::DirectedEdge* edge) const;
+
+  /**
+   * Returns the time (in seconds) to traverse the edge.
+   * @param edge  Pointer to a directed edge.
+   * @return  Returns the time in seconds to traverse the edge.
+   */
+  virtual float Seconds(const baldr::DirectedEdge* edge) const;
+
+  /**
+   * Get the cost factor for A* heuristics. This factor is multiplied
+   * with the distance to the destination to produce an estimate of the
+   * minimum cost to the destination. The A* heuristic must underestimate the
+   * cost to the destination. So a time based estimate based on speed should
+   * assume the maximum speed is used to the destination such that the time
+   * estimate is less than the least possible time along roads.
+   */
+  virtual float AStarCostFactor() const;
+
+  /**
+   * Get the general unit size that can be considered as equal for sorting
+   * purposes. The A* method uses an approximate bucket sort, and this value
+   * is used to size the buckets used for sorting. For example, for time
+   * based costs one might compute costs in seconds and consider any time
+   * within 1.5 seconds of each other as being equal (for sorting purposes).
+   * @return  Returns the unit size for sorting.
+   */
+  virtual float UnitSize() const;
+
+ protected:
+  float speedfactor_[256];
+};
+
 
 // Constructor
 AutoCost::AutoCost()
@@ -24,7 +95,7 @@ AutoCost::~AutoCost() {
 
 // Check if access is allowed on the specified edge.
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,  const bool uturn,
-                       const float dist2dest) {
+                       const float dist2dest) const {
   // Do not allow Uturns or entering no-thru edges. TODO - evaluate later!
   if (uturn || (edge->not_thru() && dist2dest > 5.0)) {
     return false;
@@ -33,20 +104,20 @@ bool AutoCost::Allowed(const baldr::DirectedEdge* edge,  const bool uturn,
 }
 
 // Check if access is allowed at the specified node.
-bool AutoCost::Allowed(const baldr::NodeInfo* node) {
+bool AutoCost::Allowed(const baldr::NodeInfo* node) const  {
   // TODO
   return true;
 }
 
 // Get the cost to traverse the edge in seconds.
-float AutoCost::Get(const DirectedEdge* edge) {
+float AutoCost::Get(const DirectedEdge* edge) const {
   if (edge->speed() > 150) {
     std::cout << "Speed = " << static_cast<uint32_t>(edge->speed()) << std::endl;
   }
   return edge->length() * speedfactor_[edge->speed()];
 }
 
-float AutoCost::Seconds(const DirectedEdge* edge) {
+float AutoCost::Seconds(const DirectedEdge* edge) const {
   return edge->length() * speedfactor_[edge->speed()];
 }
 
@@ -58,7 +129,7 @@ float AutoCost::Seconds(const DirectedEdge* edge) {
  * assume the maximum speed is used to the destination such that the time
  * estimate is less than the least possible time along roads.
  */
-float AutoCost::AStarCostFactor() {
+float AutoCost::AStarCostFactor() const {
   // This should be multiplied by the maximum speed expected.
   return speedfactor_[120];
 }
@@ -66,6 +137,10 @@ float AutoCost::AStarCostFactor() {
 float AutoCost::UnitSize() const {
   // Consider anything within 1 sec to be same cost
   return 1.0f;
+}
+
+cost_ptr_t CreateAutoHeuristic(/*pt::ptree const& config*/) {
+  return std::make_shared<AutoCost>();
 }
 
 }

--- a/src/thor/autocost.cc
+++ b/src/thor/autocost.cc
@@ -139,7 +139,7 @@ float AutoCost::UnitSize() const {
   return 1.0f;
 }
 
-cost_ptr_t CreateAutoHeuristic(/*pt::ptree const& config*/) {
+cost_ptr_t CreateAutoCost(/*pt::ptree const& config*/) {
   return std::make_shared<AutoCost>();
 }
 

--- a/src/thor/bicyclecost.cc
+++ b/src/thor/bicyclecost.cc
@@ -130,7 +130,7 @@ float BicycleCost::UnitSize() const {
   return 2.0f;
 }
 
-cost_ptr_t CreateBicycleHeuristic(/*pt::ptree const& config*/){
+cost_ptr_t CreateBicycleCost(/*pt::ptree const& config*/){
   return std::make_shared<BicycleCost>();
 }
 

--- a/src/thor/bicyclecost.cc
+++ b/src/thor/bicyclecost.cc
@@ -1,9 +1,76 @@
 #include "thor/bicyclecost.h"
+#include <valhalla/baldr/directededge.h>
+#include <valhalla/baldr/nodeinfo.h>
 
 using namespace valhalla::baldr;
 
 namespace valhalla {
 namespace thor {
+
+/**
+ * Derived class providing dynamic edge costing for pedestrian routes.
+ */
+class BicycleCost : public DynamicCost {
+ public:
+  BicycleCost();
+
+  virtual ~BicycleCost();
+
+  /**
+   * Checks if access is allowed for the provided directed edge.
+   * This is generally based on mode of travel and the access modes
+   * allowed on the edge. However, it can be extended to exclude access
+   * based on other parameters.
+   * @param edge      Pointer to a directed edge.
+   * @param uturn     Is this a Uturn?
+   * @param dist2dest Distance to the destination.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+                       const float dist2dest) const;
+
+  /**
+   * Checks if access is allowed for the provided node. Node access can
+   * be restricted if bollards or gates are present. (TODO - others?)
+   * @param  edge  Pointer to node information.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::NodeInfo* node) const;
+
+  /**
+   * Get the cost given a directed edge.
+   * @param edge  Pointer to a directed edge.
+   * @return  Returns the cost to traverse the edge.
+   */
+  virtual float Get(const baldr::DirectedEdge* edge) const;
+
+  /**
+   * Returns the time (in seconds) to traverse the edge.
+   * @param edge  Pointer to a directed edge.
+   * @return  Returns the time in seconds to traverse the edge.
+   */
+  virtual float Seconds(const baldr::DirectedEdge* edge) const;
+
+  /**
+   * Get the cost factor for A* heuristics. This factor is multiplied
+   * with the distance to the destination to produce an estimate of the
+   * minimum cost to the destination. The A* heuristic must underestimate the
+   * cost to the destination. So a time based estimate based on speed should
+   * assume the maximum speed is used to the destination such that the time
+   * estimate is less than the least possible time along roads.
+   */
+  virtual float AStarCostFactor() const;
+
+  /**
+   * Get the general unit size that can be considered as equal for sorting
+   * purposes. The A* method uses an approximate bucket sort, and this value
+   * is used to size the buckets used for sorting. For example, for time
+   * based costs one might compute costs in seconds and consider any time
+   * within 1.5 seconds of each other as being equal (for sorting purposes).
+   * @return  Returns the unit size for sorting.
+   */
+  virtual float UnitSize() const;
+};
 
 // TODO - should bicycle routes be distance based or time based? Could alter
 // time based on hilliness?
@@ -19,7 +86,7 @@ BicycleCost::~BicycleCost() {
 
 // Check if access is allowed on the specified edge.
 bool BicycleCost::Allowed(const baldr::DirectedEdge* edge, const bool uturn,
-                          const float dist2dest) {
+                          const float dist2dest) const {
   // Check access. Do not allow entering no-thru edges
   if (!(edge->forwardaccess() & kBicycleAccess) ||
        (edge->not_thru() && dist2dest > 5.0)){
@@ -29,18 +96,18 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge, const bool uturn,
 }
 
 // Check if access is allowed at the specified node.
-bool BicycleCost::Allowed(const baldr::NodeInfo* node) {
+bool BicycleCost::Allowed(const baldr::NodeInfo* node) const {
   // TODO
   return true;
 }
 
 // Get the cost to traverse the edge in seconds.
-float BicycleCost::Get(const DirectedEdge* edge) {
+float BicycleCost::Get(const DirectedEdge* edge) const {
   // TODO - cost based on desirability of cycling.
   return edge->length() / edge->speed();
 }
 
-float BicycleCost::Seconds(const DirectedEdge* edge) {
+float BicycleCost::Seconds(const DirectedEdge* edge) const {
   // TODO - what to use for speed?
   return edge->length() / edge->speed();
 }
@@ -53,7 +120,7 @@ float BicycleCost::Seconds(const DirectedEdge* edge) {
  * assume the maximum speed is used to the destination such that the time
  * estimate is less than the least possible time along roads.
  */
-float BicycleCost::AStarCostFactor() {
+float BicycleCost::AStarCostFactor() const {
   // This should be multiplied by the maximum speed expected.
   return 1.0f / 70.0f;
 }
@@ -61,6 +128,10 @@ float BicycleCost::AStarCostFactor() {
 float BicycleCost::UnitSize() const {
   // Consider anything within 2 sec to be same cost
   return 2.0f;
+}
+
+cost_ptr_t CreateBicycleHeuristic(/*pt::ptree const& config*/){
+  return std::make_shared<BicycleCost>();
 }
 
 }

--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -46,7 +46,7 @@ std::cout << "EdgeLabel index = " << edgelabel_index_ << std::endl;
 
 // Initialize prior to finding best path
 void PathAlgorithm::Init(const PointLL& origll, const PointLL& destll,
-                DynamicCost* costing) {
+    const std::shared_ptr<DynamicCost>& costing) {
 std::cout << "Orig LL = " << origll.lat() << "," << origll.lng() << std::endl;
 std::cout << "Dest LL = " << destll.lat() << "," << destll.lng() << std::endl;
   // Set the destination and cost factor in the A* heuristic
@@ -66,7 +66,7 @@ std::cout << "Dest LL = " << destll.lat() << "," << destll.lng() << std::endl;
 // Calculate best path.
 std::vector<GraphId> PathAlgorithm::GetBestPath(const PathLocation& origin,
              const PathLocation& dest, GraphReader& graphreader,
-             DynamicCost* costing) {
+             std::shared_ptr<DynamicCost> costing) {
   // Initialize - create adjacency list, edgestatus support, A*, etc.
   Init(origin.location().latlng_, dest.location().latlng_, costing);
 
@@ -199,7 +199,7 @@ std::vector<GraphId> PathAlgorithm::GetBestPath(const PathLocation& origin,
 
 // Add an edge at the origin to the adjacency list
 void PathAlgorithm::SetOrigin(baldr::GraphReader& graphreader,
-          const PathLocation& origin, DynamicCost* costing) {
+          const PathLocation& origin, const std::shared_ptr<DynamicCost>& costing) {
   // Get sort heuristic based on distance from origin to destination
   float dist = astarheuristic_.GetDistance(origin.location().latlng_);
   float heuristic = astarheuristic_.Get(dist);

--- a/src/thor/pathtest/pathtest.cc
+++ b/src/thor/pathtest/pathtest.cc
@@ -31,9 +31,9 @@ int PathTest(GraphReader& reader, const PathLocation& origin,
              TripPath& trip_path) {
   // Register costing methods
   CostFactory<DynamicCost> factory;
-  factory.Register("auto", CreateAutoHeuristic);
-  factory.Register("bicycle", CreateBicycleHeuristic);
-  factory.Register("pedestrian", CreatePedestrianHeuristic);
+  factory.Register("auto", CreateAutoCost);
+  factory.Register("bicycle", CreateBicycleCost);
+  factory.Register("pedestrian", CreatePedestrianCost);
 
   for (auto & c : routetype)
     c = std::tolower(c);

--- a/src/thor/pathtest/pathtest.cc
+++ b/src/thor/pathtest/pathtest.cc
@@ -52,13 +52,6 @@ int PathTest(GraphReader& reader, const PathLocation& origin,
   msecs = (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000);
   std::cout << "PathAlgorithm GetBestPath took " << msecs << " ms" << std::endl;
 
-  // Try again to see how much caching improves...
-  pathalgorithm.Clear();
-  start = std::clock();
-  pathedges = pathalgorithm.GetBestPath(origin, dest, reader, cost);
-  msecs = (std::clock() - start) / (double)(CLOCKS_PER_SEC / 1000);
-  std::cout << "PathAlgorithm GetBestPath took " << msecs << " ms" << std::endl;
-
   // Form output information based on pathedges
   start = std::clock();
   TripPathBuilder trippathbuilder;

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -145,7 +145,7 @@ float PedestrianCost::UnitSize() const {
   return 0.005f;
 }
 
-cost_ptr_t CreatePedestrianHeuristic(/*pt::ptree const& config*/){
+cost_ptr_t CreatePedestrianCost(/*pt::ptree const& config*/){
   return std::make_shared<PedestrianCost>();
 }
 

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -5,11 +5,86 @@ using namespace valhalla::baldr;
 namespace valhalla {
 namespace thor {
 
+/**
+ * Derived class providing dynamic edge costing for pedestrian routes.
+ */
+class PedestrianCost : public DynamicCost {
+ public:
+  PedestrianCost();
+
+  virtual ~PedestrianCost();
+
+  /**
+   * Checks if access is allowed for the provided directed edge.
+   * This is generally based on mode of travel and the access modes
+   * allowed on the edge. However, it can be extended to exclude access
+   * based on other parameters.
+   * @param edge      Pointer to a directed edge.
+   * @param uturn     Is this a Uturn?
+   * @param dist2dest Distance to the destination.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+                       const float dist2dest) const;
+
+  /**
+   * Checks if access is allowed for the provided node. Node access can
+   * be restricted if bollards or gates are present. (TODO - others?)
+   * @param  edge  Pointer to node information.
+   * @return  Returns true if access is allowed, false if not.
+   */
+  virtual bool Allowed(const baldr::NodeInfo* node) const;
+
+  /**
+   * Get the cost given a directed edge.
+   * @param edge  Pointer to a directed edge.
+   * @return  Returns the cost to traverse the edge.
+   */
+  virtual float Get(const baldr::DirectedEdge* edge) const;
+
+  /**
+   * Returns the time (in seconds) to traverse the edge.
+   * @param edge  Pointer to a directed edge.
+   * @return  Returns the time in seconds to traverse the edge.
+   */
+  virtual float Seconds(const baldr::DirectedEdge* edge) const;
+
+  /**
+   * Get the cost factor for A* heuristics. This factor is multiplied
+   * with the distance to the destination to produce an estimate of the
+   * minimum cost to the destination. The A* heuristic must underestimate the
+   * cost to the destination. So a time based estimate based on speed should
+   * assume the maximum speed is used to the destination such that the time
+   * estimate is less than the least possible time along roads.
+   */
+  virtual float AStarCostFactor() const;
+
+  /**
+   * Get the general unit size that can be considered as equal for sorting
+   * purposes. The A* method uses an approximate bucket sort, and this value
+   * is used to size the buckets used for sorting. For example, for time
+   * based costs one might compute costs in seconds and consider any time
+   * within 1.5 seconds of each other as being equal (for sorting purposes).
+   * @return  Returns the unit size for sorting.
+   */
+  virtual float UnitSize() const;
+
+ private:
+  // Walking speed (default to 5.1 km / hour)
+  float walkingspeed_;
+  // Favor walkways and paths? (default to 0.95f)
+  float favorwalkways_;
+};
+
 // Constructor
 PedestrianCost::PedestrianCost()
     : DynamicCost(),
       walkingspeed_(5.1f),
       favorwalkways_(0.90f) {
+
+  //TODO: load up stuff from ptree config
+  //We want to use walkways
+  favorwalkways_ = .5f;
 }
 
 // Destructor
@@ -18,7 +93,7 @@ PedestrianCost::~PedestrianCost() {
 
 // Check if access is allowed on the specified edge.
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
-                             const bool uturn, const float dist2dest) {
+                             const bool uturn, const float dist2dest) const {
   // Do not allow Uturns or entering no-thru edges
   if (uturn || (edge->not_thru() && dist2dest > 5.0)) {
     return false;
@@ -27,13 +102,13 @@ bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
 }
 
 // Check if access is allowed at the specified node.
-bool PedestrianCost::Allowed(const baldr::NodeInfo* node) {
+bool PedestrianCost::Allowed(const baldr::NodeInfo* node) const {
   // TODO
   return true;
 }
 
 // Get the cost to traverse the edge
-float PedestrianCost::Get(const DirectedEdge* edge) {
+float PedestrianCost::Get(const DirectedEdge* edge) const {
   // TODO - slightly avoid steps?
 
   // Slightly favor walkways/paths.
@@ -45,7 +120,7 @@ float PedestrianCost::Get(const DirectedEdge* edge) {
 }
 
 // Returns the time (in seconds) to traverse the edge.
-float PedestrianCost::Seconds(const baldr::DirectedEdge* edge) {
+float PedestrianCost::Seconds(const baldr::DirectedEdge* edge) const {
   return edge->length() / walkingspeed_;
 }
 
@@ -57,7 +132,7 @@ float PedestrianCost::Seconds(const baldr::DirectedEdge* edge) {
  * assume the maximum speed is used to the destination such that the time
  * estimate is less than the least possible time along roads.
  */
-float PedestrianCost::AStarCostFactor() {
+float PedestrianCost::AStarCostFactor() const {
   // Multiplied by the factor used to favor walkways/paths if < 1.0f
   if (favorwalkways_ < 1.0f)
     return 1.0f * favorwalkways_;
@@ -70,19 +145,8 @@ float PedestrianCost::UnitSize() const {
   return 0.005f;
 }
 
-// Set the walking speed
-void PedestrianCost::set_walkingspeed(const float speed) {
-  walkingspeed_ = speed;
-}
-
-// Set the walkway/path weight
-void PedestrianCost::set_favorwalkways(const float weight) {
-  favorwalkways_ = weight;
-}
-
-// Get the walkway/path weight
-float PedestrianCost::favorwalkways() const {
-  return favorwalkways_;
+cost_ptr_t CreatePedestrianHeuristic(/*pt::ptree const& config*/){
+  return std::make_shared<PedestrianCost>();
 }
 
 }

--- a/valhalla/thor/autocost.h
+++ b/valhalla/thor/autocost.h
@@ -7,10 +7,10 @@ namespace valhalla {
 namespace thor {
 
 /**
- * Create an autocost heuristic
+ * Create an autocost
  *
  */
-cost_ptr_t CreateAutoHeuristic(/*pt::ptree const& config*/);
+cost_ptr_t CreateAutoCost(/*pt::ptree const& config*/);
 
 }
 }

--- a/valhalla/thor/autocost.h
+++ b/valhalla/thor/autocost.h
@@ -1,84 +1,16 @@
 #ifndef VALHALLA_THOR_AUTOCOST_H_
 #define VALHALLA_THOR_AUTOCOST_H_
 
-#include <valhalla/baldr/directededge.h>
-#include <valhalla/baldr/nodeinfo.h>
 #include <valhalla/thor/dynamiccost.h>
 
 namespace valhalla {
 namespace thor {
 
 /**
- * Derived class providing dynamic edge costing for pedestrian routes.
+ * Create an autocost heuristic
+ *
  */
-class AutoCost : public DynamicCost {
- public:
-  AutoCost();
-
-  virtual ~AutoCost();
-
-  static DynamicCost* Create() {
-    return new AutoCost;
-  }
-
-  /**
-   * Checks if access is allowed for the provided directed edge.
-   * This is generally based on mode of travel and the access modes
-   * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param edge      Pointer to a directed edge.
-   * @param uturn     Is this a Uturn?
-   * @param dist2dest Distance to the destination.
-   * @return  Returns true if access is allowed, false if not.
-   */
-  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
-                       const float dist2dest);
-
-  /**
-   * Checks if access is allowed for the provided node. Node access can
-   * be restricted if bollards or gates are present. (TODO - others?)
-   * @param  edge  Pointer to node information.
-   * @return  Returns true if access is allowed, false if not.
-   */
-  virtual bool Allowed(const baldr::NodeInfo* node);
-
-  /**
-   * Get the cost given a directed edge.
-   * @param edge  Pointer to a directed edge.
-   * @return  Returns the cost to traverse the edge.
-   */
-  virtual float Get(const baldr::DirectedEdge* edge);
-
-  /**
-   * Returns the time (in seconds) to traverse the edge.
-   * @param edge  Pointer to a directed edge.
-   * @return  Returns the time in seconds to traverse the edge.
-   */
-  virtual float Seconds(const baldr::DirectedEdge* edge);
-
-  /**
-   * Get the cost factor for A* heuristics. This factor is multiplied
-   * with the distance to the destination to produce an estimate of the
-   * minimum cost to the destination. The A* heuristic must underestimate the
-   * cost to the destination. So a time based estimate based on speed should
-   * assume the maximum speed is used to the destination such that the time
-   * estimate is less than the least possible time along roads.
-   */
-  virtual float AStarCostFactor();
-
-  /**
-   * Get the general unit size that can be considered as equal for sorting
-   * purposes. The A* method uses an approximate bucket sort, and this value
-   * is used to size the buckets used for sorting. For example, for time
-   * based costs one might compute costs in seconds and consider any time
-   * within 1.5 seconds of each other as being equal (for sorting purposes).
-   * @return  Returns the unit size for sorting.
-   */
-  virtual float UnitSize() const;
-
- protected:
-  float speedfactor_[256];
-};
+cost_ptr_t CreateAutoHeuristic(/*pt::ptree const& config*/);
 
 }
 }

--- a/valhalla/thor/bicyclecost.h
+++ b/valhalla/thor/bicyclecost.h
@@ -7,10 +7,10 @@ namespace valhalla {
 namespace thor {
 
 /**
- * Create an bicyclecost heuristic
+ * Create a bicyclecost
  *
  */
-cost_ptr_t CreateBicycleHeuristic(/*pt::ptree const& config*/);
+cost_ptr_t CreateBicycleCost(/*pt::ptree const& config*/);
 
 }
 }

--- a/valhalla/thor/bicyclecost.h
+++ b/valhalla/thor/bicyclecost.h
@@ -1,81 +1,16 @@
 #ifndef VALHALLA_THOR_BICYCLECOST_H_
 #define VALHALLA_THOR_BICYCLECOST_H_
 
-#include <valhalla/baldr/directededge.h>
-#include <valhalla/baldr/nodeinfo.h>
 #include <valhalla/thor/dynamiccost.h>
 
 namespace valhalla {
 namespace thor {
 
 /**
- * Derived class providing dynamic edge costing for pedestrian routes.
+ * Create an bicyclecost heuristic
+ *
  */
-class BicycleCost : public DynamicCost {
- public:
-  BicycleCost();
-
-  virtual ~BicycleCost();
-
-  static DynamicCost* Create() {
-    return new BicycleCost;
-  }
-
-  /**
-   * Checks if access is allowed for the provided directed edge.
-   * This is generally based on mode of travel and the access modes
-   * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param edge      Pointer to a directed edge.
-   * @param uturn     Is this a Uturn?
-   * @param dist2dest Distance to the destination.
-   * @return  Returns true if access is allowed, false if not.
-   */
-  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
-                       const float dist2dest);
-
-  /**
-   * Checks if access is allowed for the provided node. Node access can
-   * be restricted if bollards or gates are present. (TODO - others?)
-   * @param  edge  Pointer to node information.
-   * @return  Returns true if access is allowed, false if not.
-   */
-  virtual bool Allowed(const baldr::NodeInfo* node);
-
-  /**
-   * Get the cost given a directed edge.
-   * @param edge  Pointer to a directed edge.
-   * @return  Returns the cost to traverse the edge.
-   */
-  virtual float Get(const baldr::DirectedEdge* edge);
-
-  /**
-   * Returns the time (in seconds) to traverse the edge.
-   * @param edge  Pointer to a directed edge.
-   * @return  Returns the time in seconds to traverse the edge.
-   */
-  virtual float Seconds(const baldr::DirectedEdge* edge);
-
-  /**
-   * Get the cost factor for A* heuristics. This factor is multiplied
-   * with the distance to the destination to produce an estimate of the
-   * minimum cost to the destination. The A* heuristic must underestimate the
-   * cost to the destination. So a time based estimate based on speed should
-   * assume the maximum speed is used to the destination such that the time
-   * estimate is less than the least possible time along roads.
-   */
-  virtual float AStarCostFactor();
-
-  /**
-   * Get the general unit size that can be considered as equal for sorting
-   * purposes. The A* method uses an approximate bucket sort, and this value
-   * is used to size the buckets used for sorting. For example, for time
-   * based costs one might compute costs in seconds and consider any time
-   * within 1.5 seconds of each other as being equal (for sorting purposes).
-   * @return  Returns the unit size for sorting.
-   */
-  virtual float UnitSize() const;
-};
+cost_ptr_t CreateBicycleHeuristic(/*pt::ptree const& config*/);
 
 }
 }

--- a/valhalla/thor/costfactory.h
+++ b/valhalla/thor/costfactory.h
@@ -15,10 +15,12 @@ namespace thor {
 /**
 * Generic factory class for creating objects based on type name.
 */
-template <typename T>
+template <class heuristic_t>
 class CostFactory {
  public:
-  typedef std::map<std::string, DynamicCost*> func_map_t;
+  typedef std::shared_ptr<heuristic_t> heuristic_ptr_t;
+  //TODO: might want to have some configurable params to each heuristic type
+  typedef heuristic_ptr_t (*factory_function_t)(/*pt::ptree const& config*/);
 
   /**
    * Constructor
@@ -28,23 +30,32 @@ class CostFactory {
   }
 
   /**
-   * Register
+   * Register the callback to create this type of heuristic
+   *
+   * @param name       the name of the heuristic that the function creates
+   * @param function   the function pointer to call to actually create the heuristic object
    */
-  CostFactory& Register(const std::string& type, DynamicCost* obj) {
-    factory_funcs_.insert(std::make_pair(type, obj));
-    return (*this);
+  void Register(const std::string& name, factory_function_t function) {
+    factory_funcs_.emplace(name, function);
   }
 
-  DynamicCost* Create(const std::string& type) const {
-    auto itr = factory_funcs_.find(type);
+  /**
+   * Make a heuristic from its name
+   *
+   * @param name    the name of the heuristic to create
+   * TODO: add configuration for the heuristic options
+   */
+  heuristic_ptr_t Create(const std::string& name/*, pt::ptree const& config*/) const {
+    auto itr = factory_funcs_.find(name);
     if (itr == factory_funcs_.end()) {
-      throw std::runtime_error("Unrecognized type: " + type);
+      throw std::runtime_error("Unrecognized heuristic name: " + name);
     }
-    return itr->second;
+    //create the heuristic using the function pointer
+    return itr->second();
   }
 
  private:
-  func_map_t factory_funcs_;
+  std::map<std::string, factory_function_t> factory_funcs_;
 };
 
 }

--- a/valhalla/thor/costfactory.h
+++ b/valhalla/thor/costfactory.h
@@ -15,12 +15,12 @@ namespace thor {
 /**
 * Generic factory class for creating objects based on type name.
 */
-template <class heuristic_t>
+template <class cost_t>
 class CostFactory {
  public:
-  typedef std::shared_ptr<heuristic_t> heuristic_ptr_t;
-  //TODO: might want to have some configurable params to each heuristic type
-  typedef heuristic_ptr_t (*factory_function_t)(/*pt::ptree const& config*/);
+  typedef std::shared_ptr<cost_t> cost_ptr_t;
+  //TODO: might want to have some configurable params to each cost type
+  typedef cost_ptr_t (*factory_function_t)(/*pt::ptree const& config*/);
 
   /**
    * Constructor
@@ -30,27 +30,27 @@ class CostFactory {
   }
 
   /**
-   * Register the callback to create this type of heuristic
+   * Register the callback to create this type of cost
    *
-   * @param name       the name of the heuristic that the function creates
-   * @param function   the function pointer to call to actually create the heuristic object
+   * @param name       the name of the cost that the function creates
+   * @param function   the function pointer to call to actually create the cost object
    */
   void Register(const std::string& name, factory_function_t function) {
     factory_funcs_.emplace(name, function);
   }
 
   /**
-   * Make a heuristic from its name
+   * Make a cost from its name
    *
-   * @param name    the name of the heuristic to create
-   * TODO: add configuration for the heuristic options
+   * @param name    the name of the cost to create
+   * TODO: add configuration for the cost options
    */
-  heuristic_ptr_t Create(const std::string& name/*, pt::ptree const& config*/) const {
+  cost_ptr_t Create(const std::string& name/*, pt::ptree const& config*/) const {
     auto itr = factory_funcs_.find(name);
     if (itr == factory_funcs_.end()) {
-      throw std::runtime_error("Unrecognized heuristic name: " + name);
+      throw std::runtime_error("Unrecognized cost name: " + name);
     }
-    //create the heuristic using the function pointer
+    //create the cost using the function pointer
     return itr->second();
   }
 

--- a/valhalla/thor/dynamiccost.h
+++ b/valhalla/thor/dynamiccost.h
@@ -3,6 +3,7 @@
 
 #include <valhalla/baldr/directededge.h>
 #include <valhalla/baldr/nodeinfo.h>
+#include <memory>
 
 namespace valhalla {
 namespace thor {
@@ -18,7 +19,7 @@ class DynamicCost {
  public:
   DynamicCost();
 
-  virtual ~DynamicCost() = 0;
+  virtual ~DynamicCost();
 
   /**
    * Checks if access is allowed for the provided directed edge.
@@ -31,7 +32,7 @@ class DynamicCost {
    * @return  Returns true if access is allowed, false if not.
    */
   virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
-                       const float dist2dest) = 0;
+                       const float dist2dest) const = 0;
 
   /**
    * Checks if access is allowed for the provided node. Node access can
@@ -39,21 +40,21 @@ class DynamicCost {
    * @param  edge  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::NodeInfo* node) = 0;
+  virtual bool Allowed(const baldr::NodeInfo* node) const = 0;
 
   /**
    * Get the cost given a directed edge.
    * @param edge  Pointer to a directed edge.
    * @return  Returns the cost to traverse the edge.
    */
-  virtual float Get(const baldr::DirectedEdge* edge) = 0;
+  virtual float Get(const baldr::DirectedEdge* edge) const = 0;
 
   /**
    * Returns the time (in seconds) to traverse the edge.
    * @param edge  Pointer to a directed edge.
    * @return  Returns the time in seconds to traverse the edge.
    */
-  virtual float Seconds(const baldr::DirectedEdge* edge) = 0;
+  virtual float Seconds(const baldr::DirectedEdge* edge) const = 0;
 
 
   /**
@@ -64,7 +65,7 @@ class DynamicCost {
    * assume the maximum speed is used to the destination such that the time
    * estimate is less than the least possible time along roads.
    */
-  virtual float AStarCostFactor() = 0;
+  virtual float AStarCostFactor() const = 0;
 
   /**
    * Get the general unit size that can be considered as equal for sorting
@@ -76,6 +77,8 @@ class DynamicCost {
    */
   virtual float UnitSize() const = 0;
 };
+
+typedef std::shared_ptr<DynamicCost> cost_ptr_t;
 
 }
 }

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -37,7 +37,7 @@ class PathAlgorithm {
    */
   std::vector<baldr::GraphId> GetBestPath(const baldr::PathLocation& origin,
           const baldr::PathLocation& dest, baldr::GraphReader& graphreader,
-           DynamicCost* costing);
+          std::shared_ptr<DynamicCost> costing);
 
   /**
    * Clear the temporary information generated during path construction.
@@ -70,13 +70,13 @@ class PathAlgorithm {
    * Initialize
    */
   void Init(const PointLL& origll, const PointLL& destll,
-            DynamicCost* costing);
+      const std::shared_ptr<DynamicCost>& costing);
 
   /**
    * Add edges at the origin to the adjacency list
    */
   void SetOrigin(baldr::GraphReader& graphreader,
-        const baldr::PathLocation& origin, DynamicCost* costing);
+        const baldr::PathLocation& origin, const std::shared_ptr<DynamicCost>& costing);
 
   /**
    * Set the destination edge(s).

--- a/valhalla/thor/pedestriancost.h
+++ b/valhalla/thor/pedestriancost.h
@@ -9,10 +9,10 @@ namespace valhalla {
 namespace thor {
 
 /**
- * Create an pedestriancost heuristic
+ * Create a pedestriancost
  *
  */
-cost_ptr_t CreatePedestrianHeuristic(/*pt::ptree const& config*/);
+cost_ptr_t CreatePedestrianCost(/*pt::ptree const& config*/);
 
 }
 }

--- a/valhalla/thor/pedestriancost.h
+++ b/valhalla/thor/pedestriancost.h
@@ -9,97 +9,10 @@ namespace valhalla {
 namespace thor {
 
 /**
- * Derived class providing dynamic edge costing for pedestrian routes.
+ * Create an pedestriancost heuristic
+ *
  */
-class PedestrianCost : public DynamicCost {
- public:
-  PedestrianCost();
-
-  virtual ~PedestrianCost();
-
-  static DynamicCost* Create() {
-    return new PedestrianCost;
-  }
-
-  /**
-   * Checks if access is allowed for the provided directed edge.
-   * This is generally based on mode of travel and the access modes
-   * allowed on the edge. However, it can be extended to exclude access
-   * based on other parameters.
-   * @param edge      Pointer to a directed edge.
-   * @param uturn     Is this a Uturn?
-   * @param dist2dest Distance to the destination.
-   * @return  Returns true if access is allowed, false if not.
-   */
-  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
-                       const float dist2dest);
-
-  /**
-   * Checks if access is allowed for the provided node. Node access can
-   * be restricted if bollards or gates are present. (TODO - others?)
-   * @param  edge  Pointer to node information.
-   * @return  Returns true if access is allowed, false if not.
-   */
-  virtual bool Allowed(const baldr::NodeInfo* node);
-
-  /**
-   * Get the cost given a directed edge.
-   * @param edge  Pointer to a directed edge.
-   * @return  Returns the cost to traverse the edge.
-   */
-  virtual float Get(const baldr::DirectedEdge* edge);
-
-  /**
-   * Returns the time (in seconds) to traverse the edge.
-   * @param edge  Pointer to a directed edge.
-   * @return  Returns the time in seconds to traverse the edge.
-   */
-  virtual float Seconds(const baldr::DirectedEdge* edge);
-
-  /**
-   * Get the cost factor for A* heuristics. This factor is multiplied
-   * with the distance to the destination to produce an estimate of the
-   * minimum cost to the destination. The A* heuristic must underestimate the
-   * cost to the destination. So a time based estimate based on speed should
-   * assume the maximum speed is used to the destination such that the time
-   * estimate is less than the least possible time along roads.
-   */
-  virtual float AStarCostFactor();
-
-  /**
-   * Get the general unit size that can be considered as equal for sorting
-   * purposes. The A* method uses an approximate bucket sort, and this value
-   * is used to size the buckets used for sorting. For example, for time
-   * based costs one might compute costs in seconds and consider any time
-   * within 1.5 seconds of each other as being equal (for sorting purposes).
-   * @return  Returns the unit size for sorting.
-   */
-  virtual float UnitSize() const;
-
-  /**
-   * Set the walking speed.
-   * @param  speed  Walking speed in kph.
-   */
-  void set_walkingspeed(const float speed);
-
-  /**
-   * Set the favor walkway/path weight.
-   * @param  weight  Favor walkway weight.
-   */
-  void set_favorwalkways(const float weight);
-
-  /**
-   * Get the favor walkway/path weight.
-   * @return  Returns the favor walkway weight.
-   */
-  float favorwalkways() const;
-
- private:
-  // Walking speed (default to 5.1 km / hour)
-  float walkingspeed_;
-  // Favor walkways and paths? (default to 0.95f)
-  float favorwalkways_;
-};
+cost_ptr_t CreatePedestrianHeuristic(/*pt::ptree const& config*/);
 
 }
 }


### PR DESCRIPTION
this moves around a bunch of code but properly sets up the factory so that the caller doesnt have to know about the underlying implementation. the way it works is:

a user of the factory makes a factory object templated by the base class of the type of objects you want the factory to produce

you then register the various objects the factory can produce by sending the factory function pointers (callbacks) to methods that can create objects that derive from the templated base class above

the function pointers basically just point to the constructors of the pimpl for each heuristic

we should at some point add sending a boost ptree to these so as to be able to configure each ones individual options