### PR TITLE
Simple hierarchy access rules

### DIFF
--- a/src/thor/autocost.cc
+++ b/src/thor/autocost.cc
@@ -96,8 +96,23 @@ AutoCost::~AutoCost() {
 // Check if access is allowed on the specified edge.
 bool AutoCost::Allowed(const baldr::DirectedEdge* edge,  const bool uturn,
                        const float dist2dest) const {
-  // Do not allow Uturns or entering no-thru edges. TODO - evaluate later!
-  if (uturn || (edge->not_thru() && dist2dest > 5.0)) {
+  // TODO - test and add options for hierarchy transitions
+  // Allow upward transitions except when close to the destination
+  if (edge->trans_up()) {
+    return dist2dest > 10.0f;
+  }
+
+  // Allow downward transitions only when near the destination
+  if (edge->trans_down()) {
+    return dist2dest < 50.0f;
+  }
+
+  // Do not allow Uturns or entering no-thru edges.
+  // TODO - evaluate later!
+  // TODO - until the opp_index is set in the new hierarchies do not test
+  // for uturn!
+//  if (uturn || (edge->not_thru() && dist2dest > 5.0))
+  if ((edge->not_thru() && dist2dest > 5.0)) {
     return false;
   }
   return (edge->forwardaccess() & kAutoAccess);

--- a/src/thor/bicyclecost.cc
+++ b/src/thor/bicyclecost.cc
@@ -87,8 +87,10 @@ BicycleCost::~BicycleCost() {
 // Check if access is allowed on the specified edge.
 bool BicycleCost::Allowed(const baldr::DirectedEdge* edge, const bool uturn,
                           const float dist2dest) const {
-  // Check access. Do not allow entering no-thru edges
-  if (!(edge->forwardaccess() & kBicycleAccess) ||
+  // Do not allow upward transitions (always stay at local level)
+  // Check access. Also do not allow Uturns or entering no-thru edges
+  // TODO - may want to revisit allowing transitions?
+  if (edge->trans_up() || !(edge->forwardaccess() & kBicycleAccess) ||
        (edge->not_thru() && dist2dest > 5.0)){
     return false;
   }

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -94,8 +94,9 @@ PedestrianCost::~PedestrianCost() {
 // Check if access is allowed on the specified edge.
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const bool uturn, const float dist2dest) const {
-  // Do not allow Uturns or entering no-thru edges
-  if (uturn || (edge->not_thru() && dist2dest > 5.0)) {
+  // Do not allow upward transitions (always stay at local level)
+  // Also do not allow Uturns or entering no-thru edges
+  if (edge->trans_up() || uturn || (edge->not_thru() && dist2dest > 5.0)) {
     return false;
   }
   return (edge->forwardaccess() & kPedestrianAccess);


### PR DESCRIPTION
Pedestrian and bicycle never allow upward transitions (and thus should never even see downward transitions).
Auto - allow upward transitions until close to the destination and downward transitions only when near the destination. Need to add some tuning and logic based on which level currently on but this at least allows some verification of the graph hierarchy. Seems to transition up and down levels, but without shortcut edges there is a slight performance loss.