### PR TITLE
Fix nodeinfo when transition up/down a level.

### DIFF
--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -27,7 +27,7 @@ TripPath TripPathBuilder::Build(GraphReader& graphreader,
                                 const std::vector<GraphId>& pathedges) {
   // TripPath is a protocol buffer that contains information about the trip
   TripPath trip_path;
-std::cout << "Build trip path" << std::endl;
+
   // TODO - what about the first node? Probably should pass it in?
   uint32_t shortcutcount = 0;
   const NodeInfo* nodeinfo = nullptr;


### PR DESCRIPTION
Still need a way to find the opposing edge to the incoming edge when a level transition has occurred.