### PR TITLE
partial distance and path finding edge cases

### DIFF
--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -26,18 +26,21 @@ void AddPartialShape(std::vector<PointLL>& shape, iter start, iter end, float pa
       shape.insert(shape.begin(), point);
   };
 
-  //for each segment
-  push(*start);
-  for(; start != end - 1; ++start) {
-    //is this segment longer than what we have left, then we found the segment the point lies on
-    const auto length = (start + 1)->Distance(*start);
-    if(length > partial_length) {
-      push(last);
-      return;
+  //yeah we dont add shape if we dont have any length to add
+  if(partial_length > 0.f) {
+    //for each segment
+    push(*start);
+    for(; start != end - 1; ++start) {
+      //is this segment longer than what we have left, then we found the segment the point lies on
+      const auto length = (start + 1)->Distance(*start);
+      if(length > partial_length) {
+        push(last);
+        return;
+      }
+      //just take the point from this segment
+      push(*(start + 1));
+      partial_length -= length;
     }
-    //just take the point from this segment
-    push(*(start + 1));
-    partial_length -= length;
   }
 }
 
@@ -196,6 +199,11 @@ TripPath TripPathBuilder::Build(GraphReader& graphreader,
 
   // Add the last node
   trip_path.add_node();
+
+  // If the path was only one edge we have a special case and the shape must be fixed up
+  if(pathedges.size() == 1) {
+
+  }
 
 /** TODO - remove debug later
   LOG_TRACE("Took " + std::to_string(shortcutcount) + " shortcut edges out of " +


### PR DESCRIPTION
this pr fixes a bunch of edge cases with partial distance and trivial pathes. if you start and end on the same link (and you are traveling in the right direction) the shape should be correct. it also fixes routes that end or start on nodes in terms of their shape (used to have duplicated points).

it doesnt fix loops, it doesnt fix pathfinding taking a longer route because it encounters the one destination edge first but has a worse partial distance than would have been if we waited to find the other edge with smaller partial distance. these will have to wait for another pr.