### PR TITLE
Add simple turn restrictions

### DIFF
--- a/src/thor/autocost.cc
+++ b/src/thor/autocost.cc
@@ -26,11 +26,15 @@ class AutoCost : public DynamicCost {
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
    * @param edge      Pointer to a directed edge.
+   * @param restriction Restriction mask. Identifies the edges at the end
+   *                  node onto which turns are restricted at all times.
+   *                  This mask is compared to the next edge's localedgeidx.
    * @param uturn     Is this a Uturn?
    * @param dist2dest Distance to the destination.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+  virtual bool Allowed(const baldr::DirectedEdge* edge,
+                       const uint32_t restriction, const bool uturn,
                        const float dist2dest) const;
 
   /**
@@ -107,8 +111,14 @@ AutoCost::~AutoCost() {
 }
 
 // Check if access is allowed on the specified edge.
-bool AutoCost::Allowed(const baldr::DirectedEdge* edge,  const bool uturn,
+bool AutoCost::Allowed(const baldr::DirectedEdge* edge,
+                       const uint32_t restriction, const bool uturn,
                        const float dist2dest) const {
+  // Check for simple turn restrictions.
+  if (restriction & (1 << edge->localedgeidx())) {
+    return false;
+  }
+
   // TODO - test and add options for hierarchy transitions
   // Allow upward transitions except when close to the destination
   if (edge->trans_up()) {

--- a/src/thor/bicyclecost.cc
+++ b/src/thor/bicyclecost.cc
@@ -29,11 +29,15 @@ class BicycleCost : public DynamicCost {
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
    * @param edge      Pointer to a directed edge.
+   * @param restriction Restriction mask. Identifies the edges at the end
+   *                  node onto which turns are restricted at all times.
+   *                  This mask is compared to the next edge's localedgeidx.
    * @param uturn     Is this a Uturn?
    * @param dist2dest Distance to the destination.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+  virtual bool Allowed(const baldr::DirectedEdge* edge,
+                       const uint32_t restriction, const bool uturn,
                        const float dist2dest) const;
 
   /**
@@ -161,8 +165,15 @@ BicycleCost::~BicycleCost() {
 }
 
 // Check if access is allowed on the specified edge.
-bool BicycleCost::Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
+                          const uint32_t restriction, const bool uturn,
                           const float dist2dest) const {
+  // Bicycles should obey vehicular turn restrictions
+  // Check for simple turn restrictions.
+  if (restriction & (1 << edge->localedgeidx())) {
+    return false;
+  }
+
   // Do not allow upward transitions (always stay at local level)
   // Check access. Also do not allow Uturns or entering no-thru edges
   // TODO - may want to revisit allowing transitions?

--- a/src/thor/edgelabel.cc
+++ b/src/thor/edgelabel.cc
@@ -19,16 +19,22 @@ EdgeLabel::EdgeLabel()
 // Constructor with values.
 EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
                      const DirectedEdge* edge, const float cost,
-                     const float sortcost, const float dist)
+                     const float sortcost, const float dist,
+                     const uint32_t restrictions)
     : predecessor_(predecessor),
       edgeid_(edgeid),
       truecost_(cost),
       sortcost_(sortcost),
       distance_(dist) {
-  endnode_                = edge->endnode();
-  attributes_.uturn_index = edge->opp_index();
-  attributes_.trans_up    = edge->trans_up();
-  attributes_.trans_down  = edge->trans_down();
+  endnode_                 = edge->endnode();
+  attributes_.uturn_index  = edge->opp_index();
+  attributes_.trans_up     = edge->trans_up();
+  attributes_.trans_down   = edge->trans_down();
+
+  // Set the simple restrictions mask. If the edge is a transition edge
+  // the prior edge restriction mask is used.
+  attributes_.restrictions = (edge->trans_up() || edge->trans_down()) ?
+        restrictions : edge->restrictions();
 }
 
 // Destructor
@@ -91,6 +97,12 @@ bool EdgeLabel::trans_up() const {
 // Get the transition down flag.
 bool EdgeLabel::trans_down() const {
   return attributes_.trans_down;
+}
+
+// Get the restriction mask at the end node. Each bit set to 1 indicates a
+// turn restriction onto the directed edge with matching local edge index.
+uint32_t EdgeLabel::restrictions() const {
+  return attributes_.restrictions;
 }
 
 // Operator for sorting.

--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -134,6 +134,7 @@ std::vector<GraphId> PathAlgorithm::GetBestPath(const PathLocation& origin,
   // Find shortest path
   uint32_t uturn_index, next_label_index;
   uint32_t prior_label_index;
+  uint32_t restriction;
   float dist2dest, dist;
   float cost, sortcost, currentcost;
   GraphId node;
@@ -203,7 +204,7 @@ std::vector<GraphId> PathAlgorithm::GetBestPath(const PathLocation& origin,
     nodeinfo =    tile->node(node);
     currentcost = nextlabel.truecost();
     uturn_index = nextlabel.uturn_index();
-
+    restriction = nextlabel.restrictions();
 
     // Check access at the node
     if (!costing->Allowed(nodeinfo)) {
@@ -220,7 +221,8 @@ std::vector<GraphId> PathAlgorithm::GetBestPath(const PathLocation& origin,
       // Skip any superseded edges if edges include shortcuts. Also skip
       // if no access is allowed to this edge (based on costing method)
       if ((has_shortcuts && directededge->superseded()) ||
-          !costing->Allowed(directededge, (i == uturn_index), dist2dest)) {
+          !costing->Allowed(directededge, restriction,
+                    (i == uturn_index), dist2dest)) {
         continue;
       }
 
@@ -273,7 +275,7 @@ std::vector<GraphId> PathAlgorithm::GetBestPath(const PathLocation& origin,
 
       // Add edge label
       edgelabels_.emplace_back(EdgeLabel(next_label_index, edgeid,
-               directededge, cost, sortcost, dist));
+               directededge, cost, sortcost, dist, restriction));
 
       // Add to the adjacency list, add to the map of edges in the adj. list
       adjacencylist_->Add(edgelabel_index_, sortcost);
@@ -327,7 +329,7 @@ void PathAlgorithm::SetOrigin(GraphReader& graphreader,
     // Add EdgeLabel to the adjacency list. Set the predecessor edge index
     // to invalid to indicate the origin of the path.
     edgelabels_.emplace_back(EdgeLabel(kInvalidLabel, edgeid,
-            directededge, cost, sortcost, dist));
+            directededge, cost, sortcost, dist, 0));
     adjacencylist_->Add(edgelabel_index_, sortcost);
     edgelabel_index_++;
   }

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -20,11 +20,13 @@ class PedestrianCost : public DynamicCost {
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
    * @param edge      Pointer to a directed edge.
+   * @param restriction Turn restrictions (not applicable for pedestrians)
    * @param uturn     Is this a Uturn?
    * @param dist2dest Distance to the destination.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+  virtual bool Allowed(const baldr::DirectedEdge* edge,
+                       const uint32_t restriction, const bool uturn,
                        const float dist2dest) const;
 
   /**
@@ -103,6 +105,7 @@ PedestrianCost::~PedestrianCost() {
 
 // Check if access is allowed on the specified edge.
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
+                             const uint32_t,
                              const bool uturn, const float dist2dest) const {
   // Do not allow upward transitions (always stay at local level)
   // Also do not allow Uturns or entering no-thru edges

--- a/valhalla/thor/dynamiccost.h
+++ b/valhalla/thor/dynamiccost.h
@@ -28,11 +28,15 @@ class DynamicCost {
    * allowed on the edge. However, it can be extended to exclude access
    * based on other parameters.
    * @param edge      Pointer to a directed edge.
+   * @param restriction Restriction mask. Identifies the edges at the end
+   *                  node onto which turns are restricted at all times.
+   *                  This mask is compared to the next edge's localedgeidx.
    * @param uturn     Is this a Uturn?
    * @param dist2dest Distance to the destination.
    * @return  Returns true if access is allowed, false if not.
    */
-  virtual bool Allowed(const baldr::DirectedEdge* edge, const bool uturn,
+  virtual bool Allowed(const baldr::DirectedEdge* edge,
+                       const uint32_t restriction, const bool uturn,
                        const float dist2dest) const = 0;
 
   /**
@@ -56,7 +60,6 @@ class DynamicCost {
    * @return  Returns the time in seconds to traverse the edge.
    */
   virtual float Seconds(const baldr::DirectedEdge* edge) const = 0;
-
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied

--- a/valhalla/thor/edgelabel.h
+++ b/valhalla/thor/edgelabel.h
@@ -30,10 +30,14 @@ class EdgeLabel {
    * @param cost      True cost to the edge.
    * @param sortcost  Cost for sorting (includes A* heuristic)
    * @param dist      Distance meters to the destination
+   * @param restrictions Restriction mask from prior edge - this is used
+   *                  if edge is a transition edge. This allows restrictions
+   *                  to be carried across different hierarchy levels.
    */
   EdgeLabel(const uint32_t predecessor, const baldr::GraphId& edgeid,
             const baldr::DirectedEdge* edge, const float cost,
-            const float sortcost, const float dist);
+            const float sortcost, const float dist,
+            const uint32_t restrictions);
 
   /**
    * Destructor.
@@ -43,7 +47,7 @@ class EdgeLabel {
   /**
    * Update an existing edge label with new predecessor and cost information.
    * The edge Id and end node remain the same.
-   * @param predecessor Predecessor directeded edge in the shortest path.
+   * @param predecessor Predecessor directed edge in the shortest path.
    * @param cost      True cost to the edge.
    * @param sortcost  Cost for sorting (includes A* heuristic)
    */
@@ -116,6 +120,13 @@ class EdgeLabel {
   bool trans_down() const;
 
   /**
+   * Get the restriction mask at the end node. Each bit set to 1 indicates a
+   * turn restriction onto the directed edge with matching local edge index.
+   * @return  Returns the restriction mask.
+   */
+  uint32_t restrictions() const;
+
+  /**
    * Operator < used for sorting.
    */
   bool operator < (const EdgeLabel& other) const;
@@ -146,12 +157,15 @@ class EdgeLabel {
    * uturn_index: Index at the end node of the edge that constitutes a U-turn
    * trans_up:    Was the prior edge a transition up to a higher level
    * trans_down:  Was the prior edge a transition down to a lower level
+   * restrictions: Bit mask of edges (by local edge index at the end node)
+   *               that are restricted (simple turn restrictions)
    */
   struct Attributes {
     uint32_t uturn_index  : 5;
     uint32_t trans_up     : 1;
     uint32_t trans_down   : 1;
-    uint32_t spare        : 25;
+    uint32_t restrictions : 7;
+    uint32_t spare        : 18;
   };
   Attributes attributes_;
 


### PR DESCRIPTION
![screenshot from 2015-02-18 14 23 55](https://cloud.githubusercontent.com/assets/1838768/6255009/df9f45b4-b77a-11e4-8183-ea3517157799.png)

Simple turn restrictions (one edge to another) are now handled. The left turn from McGovern Ave to Manheim Ave (Jordan's Curve) are properly avoided.