### PR TITLE
Add HierarchyLimits

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,7 @@ nobase_include_HEADERS = \
 	valhalla/thor/dynamiccost.h \
 	valhalla/thor/edgelabel.h \
 	valhalla/thor/edgestatus.h \
+	valhalla/thor/hierarchylimits.h \
 	valhalla/thor/pathalgorithm.h \
 	valhalla/thor/pedestriancost.h \
 	valhalla/thor/trippathbuilder.h 

--- a/src/thor/bicyclecost.cc
+++ b/src/thor/bicyclecost.cc
@@ -175,19 +175,9 @@ bool BicycleCost::Allowed(const baldr::DirectedEdge* edge,
     return false;
   }
 
-  // Do not allow uturns
-  if (uturn) {
-    return false;
-  }
-
-  // Do not allow transition onto not-thru edges except near the destination
-  if (edge->not_thru() && dist2dest > not_thru_distance_) {
-    return false;
-  }
-
-  // Do not allow upward transitions (always stay at local level)
-  // TODO - may want to revisit allowing transitions?
-  if (edge->trans_up()) {
+  // Do not allow uturns or transition onto not-thru edges (except near
+  // the destination)
+  if (uturn || (edge->not_thru() && dist2dest > not_thru_distance_)) {
     return false;
   }
 

--- a/src/thor/dynamiccost.cc
+++ b/src/thor/dynamiccost.cc
@@ -5,10 +5,22 @@ using namespace valhalla::baldr;
 namespace valhalla{
 namespace thor{
 
-DynamicCost::DynamicCost() {
+DynamicCost::DynamicCost()
+    : not_thru_distance_(5000.0f) {
 }
 
 DynamicCost::~DynamicCost() {
+}
+
+// Does the costing allow hierarchy transitions? Defaults to false. Costing
+// methods that wish to use hierarchy transitions must override this method.
+bool DynamicCost::AllowTransitions() const {
+  return false;
+}
+
+// Set the distance from the destination where "not_thru" edges are allowed.
+void DynamicCost::set_not_thru_distance(const float d) {
+  not_thru_distance_ = d;
 }
 
 }

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -107,12 +107,26 @@ PedestrianCost::~PedestrianCost() {
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const uint32_t,
                              const bool uturn, const float dist2dest) const {
-  // Do not allow upward transitions (always stay at local level)
-  // Also do not allow Uturns or entering no-thru edges
-  if (edge->trans_up() || uturn || (edge->not_thru() && dist2dest > 5.0)) {
+  // Check pedestrian access
+  if (!(edge->forwardaccess() & kPedestrianAccess)) {
     return false;
   }
-  return (edge->forwardaccess() & kPedestrianAccess);
+
+  // Do not allow uturns
+  if (uturn) {
+    return false;
+  }
+
+  // Do not allow transition onto not-thru edges except near the destination
+  if (edge->not_thru() && dist2dest > not_thru_distance_) {
+    return false;
+  }
+
+  // Do not allow upward transitions (always stay at local level)
+  if (edge->trans_up()) {
+    return false;
+  }
+  return true;
 }
 
 // Check if access is allowed at the specified node.

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -107,26 +107,10 @@ PedestrianCost::~PedestrianCost() {
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const uint32_t,
                              const bool uturn, const float dist2dest) const {
-  // Check pedestrian access
-  if (!(edge->forwardaccess() & kPedestrianAccess)) {
-    return false;
-  }
-
-  // Do not allow uturns
-  if (uturn) {
-    return false;
-  }
-
-  // Do not allow transition onto not-thru edges except near the destination
-  if (edge->not_thru() && dist2dest > not_thru_distance_) {
-    return false;
-  }
-
-  // Do not allow upward transitions (always stay at local level)
-  if (edge->trans_up()) {
-    return false;
-  }
-  return true;
+  // Return false if no pedestrian access. Disallow uturns or transition
+  // onto not-thru edges (except near the destination)
+  return ((edge->forwardaccess() & kPedestrianAccess) && !uturn &&
+          !(edge->not_thru() && dist2dest > not_thru_distance_));
 }
 
 // Check if access is allowed at the specified node.

--- a/valhalla/thor/dynamiccost.h
+++ b/valhalla/thor/dynamiccost.h
@@ -9,6 +9,9 @@
 namespace valhalla {
 namespace thor {
 
+// TODO - should edge transition costs be separate method or part of
+// the Get and Seconds methods?
+
 /**
  * Base class for dynamic edge costing. This class is an abstract class
  * defining the interface for costing methods. Derived classes must implement
@@ -21,6 +24,12 @@ class DynamicCost {
   DynamicCost();
 
   virtual ~DynamicCost();
+
+  /**
+   * Does the costing allow hierarchy transitions?
+   * @return  Returns true if the costing model allows hierarchy transitions).
+   */
+  virtual bool AllowTransitions() const;
 
   /**
    * Checks if access is allowed for the provided directed edge.
@@ -82,10 +91,22 @@ class DynamicCost {
   virtual float UnitSize() const = 0;
 
   /**
+   * Set the distance from the destination where "not_thru" edges are allowed.
+   * @param  d  Distance in meters.
+   */
+  void set_not_thru_distance(const float d);
+
+  /**
    * Returns a function/functor to be used in location searching which will
    * exclude results from the search by looking at each edges attribution
    */
   virtual const loki::EdgeFilter GetFilter() const = 0;
+
+ protected:
+  // Distance from the destination within which "not_thru" roads are
+  // considered. All costing methods exclude such roads except when close
+  // to the destination
+  float not_thru_distance_;
 };
 
 typedef std::shared_ptr<DynamicCost> cost_ptr_t;

--- a/valhalla/thor/hierarchylimits.h
+++ b/valhalla/thor/hierarchylimits.h
@@ -1,0 +1,63 @@
+#ifndef VALHALLA_THOR_HIERARCHYLIMITS_H_
+#define VALHALLA_THOR_HIERARCHYLIMITS_H_
+
+namespace valhalla {
+namespace thor {
+
+/**
+ * Hierarchy limits controls expansion and transitions between hierarchy
+ * levels. It allows limiting expansion on hierarchy levels once
+ * some number of "upward" transitions have been made (e.g. from the local
+ * level to the arterial level). Expansion on a level is allowed within some
+ * distance from the destination location. This also allows control of where
+ * upward and downward transitions are allowed based on distance from the
+ * destination.
+ */
+struct HierarchyLimits {
+  uint32_t up_transition_count;  // # of upward transitions from this level
+  uint32_t max_up_transitions;   // Maximum number of upward transitions before
+                                 // expansion is stopped on a level.
+  float expansion_within_dist;   // Distance (m) to destination within which
+                                 // expansion of a hierarchy level is
+                                 // always allowed.
+  float upward_until_dist;       // Distance (m) to destination outside which
+                                 // upward hierarchy transitions are allowed.
+  float downward_within_dist;    // Distance (m) to destination within which
+                                 // downward transitions are allowed.
+
+  /**
+   * Determine if expansion of a hierarchy level should be stopped once
+   * the number of upward transitions has been exceeded. Allows expansion
+   * within the specified distance from the destination regardless of
+   * count.
+   * @param  dist  Distance (meters) from the destination.
+   */
+  bool StopExpanding(const float dist) {
+    return (dist > expansion_within_dist &&
+            up_transition_count > max_up_transitions);
+  }
+
+  /**
+   * Determines if an upward transition should be allowed. Allows upward
+   * transitions outside the upward_until_dist distance.
+   * @param  dist  Distance (meters) from the destination.
+   */
+  bool AllowUpwardTransition(const float dist) const {
+    return dist > upward_until_dist;
+  }
+
+  /**
+   * Determines if an downward transition should be allowed. Downward
+   * transitions are allowed only within downward_within_dist from the
+   * destination.
+   * @param  dist  Distance (meters) from the destination.
+   */
+  bool AllowDownwardTransition(const float dist) const {
+    return dist < downward_within_dist;
+  }
+};
+
+}
+}
+
+#endif  // VALHALLA_THOR_HIERARCHYLIMITS_H_

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -14,6 +14,7 @@
 #include <valhalla/thor/dynamiccost.h>
 #include <valhalla/thor/edgelabel.h>
 #include <valhalla/thor/edgestatus.h>
+#include <valhalla/thor/hierarchylimits.h>
 
 namespace valhalla {
 namespace thor {
@@ -47,6 +48,8 @@ class PathAlgorithm {
   void Clear();
 
  protected:
+  // Hierarchy limits. TODO - need global contant of max # of levels
+  HierarchyLimits hierarchy_limits_[8];
 
   // A* heuristic
   AStarHeuristic astarheuristic_;


### PR DESCRIPTION
Structure that holds limits per level and does simple checks to see if expansion is allowed or transition is allowed. This allowed costing to be simplified. Next step is to hook in config settings to allow control of the limits and also allow multi-pass routes (e.g. if the first try of a route fails can increase limits).