### PR TITLE
Add property tree config to costing and use it for HierarchyLimits

### DIFF
--- a/src/thor/bicyclecost.cc
+++ b/src/thor/bicyclecost.cc
@@ -19,7 +19,12 @@ constexpr float kBicycleNetworkFactor = 0.8f;
  */
 class BicycleCost : public DynamicCost {
  public:
-  BicycleCost();
+  /**
+   * Constructor. Configuration / options for bicycle costing are provided
+   * via a property tree.
+   * @param  config  Property tree with configuration/options.
+   */
+  BicycleCost(const boost::property_tree::ptree& config);
 
   virtual ~BicycleCost();
 
@@ -151,8 +156,8 @@ class BicycleCost : public DynamicCost {
 // TODO - how to handle time/speed for estimating time on path
 
 // Constructor
-BicycleCost::BicycleCost()
-    : DynamicCost(),
+BicycleCost::BicycleCost(const boost::property_tree::ptree& config)
+    : DynamicCost(config),
       speed_(25.0f),
       bicycletype_(BicycleType::kRoad),
       smooth_surface_factor_(0.9f),
@@ -273,8 +278,8 @@ float BicycleCost::UnitSize() const {
   return 2.0f;
 }
 
-cost_ptr_t CreateBicycleCost(/*pt::ptree const& config*/){
-  return std::make_shared<BicycleCost>();
+cost_ptr_t CreateBicycleCost(const boost::property_tree::ptree& config) {
+  return std::make_shared<BicycleCost>(config);
 }
 
 }

--- a/src/thor/dynamiccost.cc
+++ b/src/thor/dynamiccost.cc
@@ -5,8 +5,13 @@ using namespace valhalla::baldr;
 namespace valhalla{
 namespace thor{
 
-DynamicCost::DynamicCost()
+DynamicCost::DynamicCost(const boost::property_tree::ptree& pt)
     : not_thru_distance_(5000.0f) {
+  // Parse property tree to get hierarchy limits
+  // TODO - get the number of levels
+  for (uint32_t level = 0; level <= 8; level++) {
+    hierarchy_limits_.emplace_back(HierarchyLimits(pt, level));
+  }
 }
 
 DynamicCost::~DynamicCost() {
@@ -16,6 +21,11 @@ DynamicCost::~DynamicCost() {
 // methods that wish to use hierarchy transitions must override this method.
 bool DynamicCost::AllowTransitions() const {
   return false;
+}
+
+// Gets the hierarchy limits.
+std::vector<HierarchyLimits>& DynamicCost::GetHierarchyLimits() {
+  return hierarchy_limits_;
 }
 
 // Set the distance from the destination where "not_thru" edges are allowed.

--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -12,7 +12,6 @@ using namespace valhalla::baldr;
 
 namespace {
 
-constexpr float    kMaxDistance = std::numeric_limits<float>::max();
 constexpr uint32_t kBucketCount = 20000;
 constexpr uint64_t kInitialEdgeLabelCount = 500000;
 
@@ -58,8 +57,7 @@ namespace thor {
 
 // Default constructor
 PathAlgorithm::PathAlgorithm()
-    : hierarchy_limits_{},
-      edgelabel_index_(0),
+    : edgelabel_index_(0),
       adjacencylist_(nullptr),
       edgestatus_(nullptr),
       best_destination_{kInvalidLabel, std::numeric_limits<float>::max()}{
@@ -112,27 +110,9 @@ void PathAlgorithm::Init(const PointLL& origll, const PointLL& destll,
   adjacencylist_ = new AdjacencyList(mincost, range, bucketsize);
   edgestatus_ = new EdgeStatus();
 
-  // Reset any hierarchy transition counts
-  for (auto& level : hierarchy_limits_) {
-    level.up_transition_count = 0;
-  }
-
-  // TODO - initialize hierarchy limits based on config/# of tries. Set up
-  // defaults...
-  hierarchy_limits_[0].max_up_transitions    = 0;
-  hierarchy_limits_[0].expansion_within_dist = kMaxDistance;
-  hierarchy_limits_[0].upward_until_dist     = 0.0f;
-  hierarchy_limits_[0].downward_within_dist  = 10000.0f;
-
-  hierarchy_limits_[1].max_up_transitions    = 250;
-  hierarchy_limits_[1].expansion_within_dist = 10000.0f;
-  hierarchy_limits_[1].upward_until_dist     = 10000.0f;
-  hierarchy_limits_[1].downward_within_dist  = 5000.0f;
-
-  hierarchy_limits_[2].max_up_transitions    = 50;
-  hierarchy_limits_[2].expansion_within_dist = 5000.0f;
-  hierarchy_limits_[2].upward_until_dist     = 5000.0f;
-  hierarchy_limits_[2].downward_within_dist  = kMaxDistance;
+  // Get hierarchy limits from the costing. Get a copy since we increment
+  // transition counts (i.e., this is not a const reference).
+  hierarchy_limits_ = costing->GetHierarchyLimits();
 }
 
 // Calculate best path.

--- a/src/thor/pathtest/pathtest.cc
+++ b/src/thor/pathtest/pathtest.cc
@@ -33,8 +33,6 @@ namespace bpo = boost::program_options;
  */
 TripPath PathTest(GraphReader& reader, const PathLocation& origin,
                   const PathLocation& dest, std::shared_ptr<DynamicCost> cost) {
-LOG_INFO("Sizeof GraphTileHeader = " + std::to_string(sizeof(GraphTileHeader)));
-
   auto t1 = std::chrono::high_resolution_clock::now();
   PathAlgorithm pathalgorithm;
   auto t2 = std::chrono::high_resolution_clock::now();
@@ -131,7 +129,7 @@ int main(int argc, char *argv[]) {
       "Destination: lat,lng,[through|stop],[name],[street],[city/town/village],[state/province/canton/district/region/department...],[zip code],[country].")(
       "type,t",
       boost::program_options::value<std::string>(&routetype),
-      "Route Type: auto|bicycle|pedestrian")
+      "Route Type: auto|bicycle|pedestrian|auto-shorter")
   // positional arguments
   ("config", bpo::value<std::string>(&config), "Valhalla configuration file");
 
@@ -184,12 +182,13 @@ int main(int argc, char *argv[]) {
   // Figure out the route type
   CostFactory<DynamicCost> factory;
   factory.Register("auto", CreateAutoCost);
+  factory.Register("auto-shorter", CreateAutoShorterCost);
   factory.Register("bicycle", CreateBicycleCost);
   factory.Register("pedestrian", CreatePedestrianCost);
 
   for (auto & c : routetype)
     c = std::tolower(c);
-  std::shared_ptr<DynamicCost> cost = factory.Create(routetype);
+  std::shared_ptr<DynamicCost> cost = factory.Create(routetype, pt.get_child("thor"));
 
   LOG_INFO("routetype: " + routetype);
 

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -10,7 +10,12 @@ namespace thor {
  */
 class PedestrianCost : public DynamicCost {
  public:
-  PedestrianCost();
+  /**
+   * Constructor. Configuration / options for pedestrian costing are provided
+   * via a property tree.
+   * @param  config  Property tree with configuration/options.
+   */
+  PedestrianCost(const boost::property_tree::ptree& config);
 
   virtual ~PedestrianCost();
 
@@ -92,11 +97,11 @@ class PedestrianCost : public DynamicCost {
 };
 
 // Constructor
-PedestrianCost::PedestrianCost()
-    : DynamicCost(),
+PedestrianCost::PedestrianCost(const boost::property_tree::ptree& config)
+    : DynamicCost(config),
       walkingspeed_(5.1f),
       favorwalkways_(0.9f) {
-  //TODO: load up stuff from ptree config
+  // TODO: parse pedestrian configuration from ptree config
 }
 
 // Destructor
@@ -154,8 +159,8 @@ float PedestrianCost::UnitSize() const {
   return 2.0f;
 }
 
-cost_ptr_t CreatePedestrianCost(/*pt::ptree const& config*/){
-  return std::make_shared<PedestrianCost>();
+cost_ptr_t CreatePedestrianCost(const boost::property_tree::ptree& config) {
+  return std::make_shared<PedestrianCost>(config);
 }
 
 }

--- a/valhalla/thor/autocost.h
+++ b/valhalla/thor/autocost.h
@@ -1,16 +1,26 @@
 #ifndef VALHALLA_THOR_AUTOCOST_H_
 #define VALHALLA_THOR_AUTOCOST_H_
 
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
 #include <valhalla/thor/dynamiccost.h>
 
 namespace valhalla {
 namespace thor {
 
 /**
- * Create an autocost
- *
+ * Create an auto route cost method. This is generally shortest time but uses
+ * hierarchies and can avoid "shortcuts" through residential areas.
  */
-cost_ptr_t CreateAutoCost(/*pt::ptree const& config*/);
+cost_ptr_t CreateAutoCost(const boost::property_tree::ptree& config);
+
+/**
+ * Create an auto shorter cost method. This is derived from auto costing and
+ * uses the same rules except the edge cost uses an adjusted speed that
+ * (non-linearly) reduces the importance of edge speed.
+ */
+cost_ptr_t CreateAutoShorterCost(const boost::property_tree::ptree& config);
 
 }
 }

--- a/valhalla/thor/bicyclecost.h
+++ b/valhalla/thor/bicyclecost.h
@@ -8,9 +8,9 @@ namespace thor {
 
 /**
  * Create a bicyclecost
- *
+ * @param  config  Property tree with configuration / options.
  */
-cost_ptr_t CreateBicycleCost(/*pt::ptree const& config*/);
+cost_ptr_t CreateBicycleCost(const boost::property_tree::ptree& config);
 
 }
 }

--- a/valhalla/thor/costfactory.h
+++ b/valhalla/thor/costfactory.h
@@ -19,7 +19,7 @@ class CostFactory {
  public:
   typedef std::shared_ptr<cost_t> cost_ptr_t;
   //TODO: might want to have some configurable params to each cost type
-  typedef cost_ptr_t (*factory_function_t)(/*pt::ptree const& config*/);
+  typedef cost_ptr_t (*factory_function_t)(const boost::property_tree::ptree& config);
 
   /**
    * Constructor
@@ -40,17 +40,17 @@ class CostFactory {
 
   /**
    * Make a cost from its name
-   *
    * @param name    the name of the cost to create
-   * TODO: add configuration for the cost options
+   * @param config  Property tree with configuration / cost options
    */
-  cost_ptr_t Create(const std::string& name/*, pt::ptree const& config*/) const {
+  cost_ptr_t Create(const std::string& name,
+                    const boost::property_tree::ptree& config) const {
     auto itr = factory_funcs_.find(name);
     if (itr == factory_funcs_.end()) {
       throw std::runtime_error("Unrecognized cost name: " + name);
     }
     //create the cost using the function pointer
-    return itr->second();
+    return itr->second(config);
   }
 
  private:

--- a/valhalla/thor/dynamiccost.h
+++ b/valhalla/thor/dynamiccost.h
@@ -6,6 +6,8 @@
 #include <valhalla/loki/search.h>
 #include <memory>
 
+#include <valhalla/thor/hierarchylimits.h>
+
 namespace valhalla {
 namespace thor {
 
@@ -21,7 +23,7 @@ namespace thor {
  */
 class DynamicCost {
  public:
-  DynamicCost();
+  DynamicCost(const boost::property_tree::ptree& pt);
 
   virtual ~DynamicCost();
 
@@ -102,7 +104,16 @@ class DynamicCost {
    */
   virtual const loki::EdgeFilter GetFilter() const = 0;
 
+  /**
+   * Gets the hierarchy limits.
+   * @return  Returns the hierarchy limits.
+   */
+  std::vector<HierarchyLimits>& GetHierarchyLimits();
+
  protected:
+  // Hierarchy limits.
+  std::vector<HierarchyLimits> hierarchy_limits_;
+
   // Distance from the destination within which "not_thru" roads are
   // considered. All costing methods exclude such roads except when close
   // to the destination

--- a/valhalla/thor/hierarchylimits.h
+++ b/valhalla/thor/hierarchylimits.h
@@ -1,6 +1,32 @@
 #ifndef VALHALLA_THOR_HIERARCHYLIMITS_H_
 #define VALHALLA_THOR_HIERARCHYLIMITS_H_
 
+// Default hierarchy transitions. Note that this corresponds to a 3 level
+// strategy: highway, arterial, local. Any changes to this will require
+// updates to the defaults.
+namespace {
+constexpr float kMaxDistance = std::numeric_limits<float>::max();
+
+// Default default maximum upward transitions (per level)
+constexpr uint32_t kDefaultMaxUpTransitions[] = {
+    0, 250, 50, 0, 0, 0, 0, 0 };
+
+// Default distances within which expansion is always allowed
+// (per level)
+constexpr float kDefaultExpansionWithinDist[] = {
+    kMaxDistance, 10000.0f, 5000.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+
+// Default distances outside which upward transitions are allowed
+// (per level)
+constexpr float kDefaultUpwardUntilDist[] = {
+    0.0f, 10000.0f, 5000.0f,  0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+
+// Default distances within which downward transitions are allowed
+// (per level)
+constexpr float kDefaultDownwardWithinDist[] = {
+    10000.0f, 5000.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+}
+
 namespace valhalla {
 namespace thor {
 
@@ -26,13 +52,41 @@ struct HierarchyLimits {
                                  // downward transitions are allowed.
 
   /**
+   * Set hierarchy limits for the specified level using a property tree.
+   * @param  pt     Property tree
+   * @param  level  Hierarchy level
+   */
+  HierarchyLimits(const boost::property_tree::ptree& pt, const uint32_t level)
+      : up_transition_count(0) {
+
+    // Construct string to identify the level of the hierarchy
+    std::string hl = "hierarchy_limits." + std::to_string(level);
+
+    // Set maximum number of upward transitions
+    max_up_transitions = pt.get<unsigned int>(hl + ".max_up_transitions",
+                    kDefaultMaxUpTransitions[level]);
+
+    // Set distance within which expansion is always allowed for this level
+    expansion_within_dist = pt.get<float>(hl + ".expansion_within_dist",
+                    kDefaultExpansionWithinDist[level]);
+
+    // Set distance outside which upward transitions are allowed
+    upward_until_dist = pt.get<float>(hl +".upward_until_dist",
+                    kDefaultUpwardUntilDist[level]);
+
+    // Set distance within which downward transitions are allowed
+    downward_within_dist = pt.get<float>(hl + ".downward_within_dist",
+                    kDefaultDownwardWithinDist[level]);
+  }
+
+  /**
    * Determine if expansion of a hierarchy level should be stopped once
    * the number of upward transitions has been exceeded. Allows expansion
    * within the specified distance from the destination regardless of
    * count.
    * @param  dist  Distance (meters) from the destination.
    */
-  bool StopExpanding(const float dist) {
+  bool StopExpanding(const float dist) const {
     return (dist > expansion_within_dist &&
             up_transition_count > max_up_transitions);
   }

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -48,8 +48,8 @@ class PathAlgorithm {
   void Clear();
 
  protected:
-  // Hierarchy limits. TODO - need global contant of max # of levels
-  HierarchyLimits hierarchy_limits_[8];
+  // Hierarchy limits.
+  std::vector<HierarchyLimits> hierarchy_limits_;
 
   // A* heuristic
   AStarHeuristic astarheuristic_;

--- a/valhalla/thor/pedestriancost.h
+++ b/valhalla/thor/pedestriancost.h
@@ -12,7 +12,7 @@ namespace thor {
  * Create a pedestriancost
  *
  */
-cost_ptr_t CreatePedestrianCost(/*pt::ptree const& config*/);
+cost_ptr_t CreatePedestrianCost(const boost::property_tree::ptree& config);
 
 }
 }


### PR DESCRIPTION
There are default hierarchy limits and now they can be overriden with property tree config. The plumbing to allow other costing options to be set/changed is also in place, though none are being used.