### PR TITLE
Costing Updates

### DIFF
--- a/src/thor/dynamiccost.cc
+++ b/src/thor/dynamiccost.cc
@@ -23,6 +23,21 @@ bool DynamicCost::AllowTransitions() const {
   return false;
 }
 
+// Returns the cost to make the transition from the predecessor edge.
+// Defaults to 0. Costing models that wish to include edge transition
+// costs (i.e., intersection/turn costs) must override this method.
+Cost DynamicCost::TransitionCost(const DirectedEdge* edge,
+                                 const NodeInfo* node,
+                                 const EdgeLabel& pred) const {
+  return Cost(0.0f, 0.0f);
+}
+
+// Get the general unit size that can be considered as equal for sorting
+// purposes. Defaults to 1 (second).
+uint32_t DynamicCost::UnitSize() const {
+  return kDefaultUnitSize;
+}
+
 // Gets the hierarchy limits.
 std::vector<HierarchyLimits>& DynamicCost::GetHierarchyLimits() {
   return hierarchy_limits_;

--- a/src/thor/edgelabel.cc
+++ b/src/thor/edgelabel.cc
@@ -26,17 +26,11 @@ EdgeLabel::EdgeLabel(const uint32_t predecessor, const GraphId& edgeid,
       truecost_(cost),
       sortcost_(sortcost),
       distance_(dist) {
-  endnode_                 = edge->endnode();
-  attributes_.uturn_index  = edge->opp_index();
-  attributes_.trans_up     = edge->trans_up();
-  attributes_.trans_down   = edge->trans_down();
-
-  // Set the simple restrictions mask. If the edge is a transition edge
-  // the prior edge restriction mask is used.
-  attributes_.restrictions = (edge->trans_up() || edge->trans_down()) ?
-        restrictions : edge->restrictions();
-
-  // Set the opposing local index.
+  endnode_                  = edge->endnode();
+  attributes_.uturn_index   = edge->opp_index();
+  attributes_.trans_up      = edge->trans_up();
+  attributes_.trans_down    = edge->trans_down();
+  attributes_.restrictions  = restrictions;
   attributes_.opp_local_idx = edge->opp_local_idx();
 }
 

--- a/valhalla/thor/edgelabel.h
+++ b/valhalla/thor/edgelabel.h
@@ -129,7 +129,7 @@ class EdgeLabel {
   /**
    * Get the opposing local index. This is the index of the incoming edge
    * (on the local hierarchy) at the end node of the predecessor directed
-   * edge. This is used for edge transition costs.
+   * edge. This is used for edge transition costs and Uturn detection.
    * @return  Returns the local index of the incoming edge.
    */
   uint32_t opp_local_idx() const;
@@ -167,14 +167,17 @@ class EdgeLabel {
    * trans_down:  Was the prior edge a transition down to a lower level
    * restrictions: Bit mask of edges (by local edge index at the end node)
    *               that are restricted (simple turn restrictions)
+   * opp_local_idx: Index at the end node of the opposing local edge. This
+   *                value can be compared to the directed edge local_edge_idx
+   *                for edge transition costing and Uturn detection.
    */
   struct Attributes {
-    uint32_t uturn_index   : 5;
+    uint32_t uturn_index   : 7;
     uint32_t trans_up      : 1;
     uint32_t trans_down    : 1;
     uint32_t restrictions  : 7;
-    uint32_t opp_local_idx : 4;
-    uint32_t spare         : 14;
+    uint32_t opp_local_idx : 7;
+    uint32_t spare         : 9;
   };
   Attributes attributes_;
 

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -48,6 +48,9 @@ class PathAlgorithm {
   void Clear();
 
  protected:
+  // Allow transitions (set from the costing model)
+  bool allow_transitions_;
+
   // Hierarchy limits.
   std::vector<HierarchyLimits> hierarchy_limits_;
 
@@ -81,6 +84,18 @@ class PathAlgorithm {
       const std::shared_ptr<DynamicCost>& costing);
 
   /**
+   * Handle transition edges. Will add any that are allowed to the
+   * adjacency list.
+   * @param level      Current hierarchy level
+   * @param edge       Directed edge (a transition edge)
+   * @param pred       Predecessor information
+   * @param predindex  Predecessor index in the edge labels.
+   */
+  void HandleTransitionEdge(const uint32_t level,const baldr::GraphId& edgeid,
+                      const baldr::DirectedEdge* edge,
+                      const EdgeLabel& pred, const uint32_t predindex);
+
+  /**
    * Add edges at the origin to the adjacency list
    */
   void SetOrigin(baldr::GraphReader& graphreader, const baldr::PathLocation& origin,
@@ -102,10 +117,15 @@ class PathAlgorithm {
 
   /**
    * Form the path from the adjacency list.
-   * TODO - support partial distances at origin/destination
+   * @param   dest  Index in the edge labels of the destination edge.
+   * @param   graphreader  Graph tile reader
+   * @param   loop   GraphId representing the loop edge (invalid if none)
+   * @return  Returns a list of GraphIds representing the directed edges
+   *          along the path - ordered from origin to destination.
    */
   std::vector<baldr::GraphId> FormPath(const uint32_t dest,
-                                       baldr::GraphReader& graphreader, const baldr::GraphId& loop);
+                                       baldr::GraphReader& graphreader,
+                                       const baldr::GraphId& loop);
 
   /**
    * TODO - are we keeping these?


### PR DESCRIPTION
Update the costing model. Splits EdgeCost from TransitionCost (intersection/turn cost). Requires a Cost structure to be returned with both cost and seconds so we can handle time/schedules. Split out hierarchy transition edges so they either get skipped or added to the adjacency list (no need to go through other logic since they have no length).