### PR TITLE
Costing - auto and pedestrian updates for pt parsing

### DIFF
--- a/conf/valhalla.json
+++ b/conf/valhalla.json
@@ -36,4 +36,23 @@
       "color": true
     }
   }
+  "costing": {
+    "auto": {
+      "maneuver_penalty": 5.0,
+      "gate_cost": 30.0,
+      "toll_booth_cost": 15.0 
+      "toll_booth_penalty": 0.0 
+    },
+    "auto-shorter": {
+    },
+    "pedestrian": {
+      "walking_speed": 5.1,
+      "walkway_factor": 0.9,
+      "alley_factor": 2.0,
+      "driveway_factor": 2.0,
+      "step_penalty": 30.0
+    },
+    "bicycle": {
+    }
+  }
 }

--- a/src/thor/dynamiccost.cc
+++ b/src/thor/dynamiccost.cc
@@ -59,6 +59,12 @@ void DynamicCost::RelaxHierarchyLimits(const float factor) {
   }
 }
 
+// Do not transition up to highway level - remain on arterial. Used as last
+// resort.
+void DynamicCost::DisableHighwayTransitions() {
+  hierarchy_limits_[1].DisableHighwayTransitions();
+}
+
 // Set the distance from the destination where "not_thru" edges are allowed.
 void DynamicCost::set_not_thru_distance(const float d) {
   not_thru_distance_ = d;

--- a/src/thor/pedestriancost.cc
+++ b/src/thor/pedestriancost.cc
@@ -7,6 +7,16 @@ using namespace valhalla::baldr;
 namespace valhalla {
 namespace thor {
 
+// Default options/values
+namespace {
+constexpr uint32_t kUnitSize = 2;
+constexpr float kDefaultWalkingSpeed   = 5.1f;   // 3.16 MPH
+constexpr float kDefaultWalkwayFactor  = 0.9f;   // Slightly favor walkways
+constexpr float kDefaultAlleyFactor    = 2.0f;   // Avoid alleys
+constexpr float kDefaultDrivewayFactor = 2.0f;   // Avoid driveways
+constexpr float kDefaultStepPenalty    = 30.0f;  // 30 seconds
+}
+
 /**
  * Derived class providing dynamic edge costing for pedestrian routes.
  */
@@ -14,10 +24,10 @@ class PedestrianCost : public DynamicCost {
  public:
   /**
    * Constructor. Configuration / options for pedestrian costing are provided
-   * via a property tree.
-   * @param  config  Property tree with configuration/options.
+   * via a property tree (JSON).
+   * @param  pt  Property tree with configuration/options.
    */
-  PedestrianCost(const boost::property_tree::ptree& config);
+  PedestrianCost(const boost::property_tree::ptree& pt);
 
   virtual ~PedestrianCost();
 
@@ -35,7 +45,7 @@ class PedestrianCost : public DynamicCost {
 
   /**
    * Checks if access is allowed for the provided node. Node access can
-   * be restricted if bollards or gates are present. (TODO - others?)
+   * be restricted if bollards or gates are present.
    * @param  edge  Pointer to node information.
    * @return  Returns true if access is allowed, false if not.
    */
@@ -58,12 +68,13 @@ class PedestrianCost : public DynamicCost {
    * @param  edge  Directed edge (the to edge)
    * @param  node  Node (intersection) where transition occurs.
    * @param  pred  Predecessor edge information.
+   * @param  to_idx Index of the "to" directed edge.
    * @return  Returns the cost and time (seconds)
    */
-// TODO - add logic for transition costs!
-//  virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
-//                               const baldr::NodeInfo* node,
-//                               const EdgeLabel& pred) const;
+  virtual Cost TransitionCost(const baldr::DirectedEdge* edge,
+                              const baldr::NodeInfo* node,
+                              const EdgeLabel& pred,
+                              const uint32_t to_idx) const;
 
   /**
    * Get the cost factor for A* heuristics. This factor is multiplied
@@ -94,35 +105,50 @@ class PedestrianCost : public DynamicCost {
 
  private:
   // Walking speed (default to 5.1 km / hour)
-  float walkingspeed_;
+  float walking_speed_;
 
+  // Speed factor for costing. Based on walking speed.
   float speedfactor_;
 
-  // Favor walkways and paths? (default to 0.9f)
-  float favorwalkways_;
+  // Factor for favoring walkways and paths. Default to 0.9.
+  float walkway_factor_;
+
+  // Avoid alleys. Default to 2.0. Double the cost to traverse an alley.
+  float alley_factor_;
+
+  // Avoid driveways. Default to 2.0. Double the cost to traverse.
+  float driveway_factor_;
+
+  // Avoid stairs/steps. This is a fixed cost in seconds.
+  float step_penalty_;
 };
 
-// Constructor
-// TODO: parse pedestrian configuration from ptree config
-PedestrianCost::PedestrianCost(const boost::property_tree::ptree& config)
-    : DynamicCost(config),
-      walkingspeed_(5.1f),
-      favorwalkways_(0.9f) {
-  speedfactor_ = (kSecPerHour * 0.001f) / walkingspeed_;
+// Constructor. Parse pedestrian options from property tree. If option is
+// not present, set the default.
+PedestrianCost::PedestrianCost(const boost::property_tree::ptree& pt)
+    : DynamicCost(pt) {
+  walking_speed_   = pt.get<float>("walking_speed", kDefaultWalkingSpeed);
+  walkway_factor_  = pt.get<float>("walkway_factor", kDefaultWalkwayFactor);
+  alley_factor_    = pt.get<float>("alley_factor_", kDefaultAlleyFactor);
+  driveway_factor_ = pt.get<float>("driveway_factor", kDefaultDrivewayFactor);
+  step_penalty_    = pt.get<float>("step_penalty", kDefaultStepPenalty);
+
+  // Set the speed factor (to avoid division in costing)
+  speedfactor_ = (kSecPerHour * 0.001f) / walking_speed_;
 }
 
 // Destructor
 PedestrianCost::~PedestrianCost() {
 }
 
-// Check if access is allowed on the specified edge.
+// Check if access is allowed on the specified edge. Disallow if no pedestrian
+// access. Disallow Uturns or entering not-thru edges except near the
+// destination. Do not allow if surface is impassable
 bool PedestrianCost::Allowed(const baldr::DirectedEdge* edge,
                              const EdgeLabel& pred) const {
-  // Return false if no pedestrian access. Disallow Uturns or entering
-  // not-thru edges except near the destination.
   return ((edge->forwardaccess() & kPedestrianAccess) &&
            pred.opp_local_idx() != edge->localedgeidx()  &&
-          !(edge->not_thru() && pred.distance() > not_thru_distance_) &&
+         !(edge->not_thru() && pred.distance() > not_thru_distance_) &&
            edge->surface() != Surface::kImpassable);
 }
 
@@ -135,32 +161,56 @@ bool PedestrianCost::Allowed(const baldr::NodeInfo* node) const {
 // (in seconds) to traverse the edge.
 Cost PedestrianCost::EdgeCost(const baldr::DirectedEdge* edge,
                               const uint32_t density) const {
-  // Slightly favor walkways/paths. TODO - penalize stairs
+  // Slightly favor walkways/paths and penalize alleys and driveways.
   float sec = edge->length() * speedfactor_;
   if (edge->use() == Use::kFootway) {
-    return Cost(sec * favorwalkways_, sec);
+    return { sec * walkway_factor_, sec };
+  } else if (edge->use() == Use::kAlley) {
+    return { sec * alley_factor_, sec };
+  } else if (edge->use() == Use::kDriveway) {
+    return { sec * driveway_factor_, sec };
   } else {
-    return Cost(sec, sec);
+    return { sec, sec };
   }
-};
+}
 
-/**
- * Get the cost factor for A* heuristics. This factor is multiplied
- * with the distance to the destination to produce an estimate of the
- * minimum cost to the destination. The A* heuristic must underestimate the
- * cost to the destination. So a time based estimate based on speed should
- * assume the maximum speed is used to the destination such that the time
- * estimate is less than the least possible time along roads.
- */
+// Returns the time (in seconds) to make the transition from the predecessor
+Cost PedestrianCost::TransitionCost(const baldr::DirectedEdge* edge,
+                               const baldr::NodeInfo* node,
+                               const EdgeLabel& pred,
+                               const uint32_t to_idx) const {
+  // Special cases: fixed penalty for steps/stairs
+  if (edge->use() == Use::kSteps) {
+    return { step_penalty_, 0.0f };
+  }
+
+  // Costs for crossing an intersection.
+  // TODO - do we want any maneuver penalty?
+  uint32_t idx = pred.opp_local_idx();
+  if (edge->edge_to_right(idx) && edge->edge_to_left(idx)) {
+    float sec = edge->stopimpact(idx);
+    return { sec, sec };
+  } else {
+    return { 0.0f, 0.0f };
+  }
+}
+
+// Get the cost factor for A* heuristics. This factor is multiplied
+// with the distance to the destination to produce an estimate of the
+// minimum cost to the destination. The A* heuristic must underestimate the
+// cost to the destination. So a time based estimate based on speed should
+// assume the maximum speed is used to the destination such that the time
+// estimate is less than the least possible time along roads.
 float PedestrianCost::AStarCostFactor() const {
   // Use the factor to favor walkways/paths if < 1.0f
-  return (favorwalkways_ < 1.0f) ? favorwalkways_ * speedfactor_ : speedfactor_;
+  return (walkway_factor_ < 1.0f) ? walkway_factor_ * speedfactor_ : speedfactor_;
 }
 
 //  Override unit size since walking costs are higher range of values
 uint32_t PedestrianCost::UnitSize() const {
-  return 2;
+  return kUnitSize;
 }
+
 cost_ptr_t CreatePedestrianCost(const boost::property_tree::ptree& config) {
   return std::make_shared<PedestrianCost>(config);
 }

--- a/valhalla/thor/dynamiccost.h
+++ b/valhalla/thor/dynamiccost.h
@@ -166,6 +166,12 @@ class DynamicCost {
   void RelaxHierarchyLimits(const float factor);
 
   /**
+   * Do not transition up to highway level - remain on arterial. Used as last
+   * resort.
+   */
+  void DisableHighwayTransitions();
+
+  /**
    * Reset hierarchy limits.
    */
   void ResetHierarchyLimits();

--- a/valhalla/thor/hierarchylimits.h
+++ b/valhalla/thor/hierarchylimits.h
@@ -117,6 +117,13 @@ struct HierarchyLimits {
     upward_until_dist *= factor;
     downward_within_dist *= factor;
   }
+
+  void DisableHighwayTransitions() {
+    up_transition_count = 0;
+    max_up_transitions = 0;
+    expansion_within_dist = kMaxDistance;
+    upward_until_dist = kMaxDistance;
+  }
 };
 
 }


### PR DESCRIPTION
Set default options, allow config JSON / property tree to override these. Added a method that can disable highway hierarchy level - need to test and see if htis is what we need to do in regions where highway hierarchy is unconnected/incomplete.