### PR TITLE
Remove index from TransitionCost.

### DIFF
--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -246,7 +246,7 @@ std::vector<PathInfo> PathAlgorithm::GetBestPath(const PathLocation& origin,
       // Get cost
       Cost newcost = pred.cost() +
                      costing->EdgeCost(directededge, nodeinfo->density()) +
-                     costing->TransitionCost(directededge, nodeinfo, pred, i);
+                     costing->TransitionCost(directededge, nodeinfo, pred);
 
       // Check if edge is temporarily labeled and this path has less cost. If
       // less cost the predecessor is updated and the sort cost is decremented


### PR DESCRIPTION
 Really wanted the localedgeidx of the directed edge. This fixes maneuver penalties on upper hierarchies.