### PR TITLE
first draft of thor service layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ libtool
 # built objects
 pathtest
 citytest
+thor_service
 *.o
 .deps/
 .dirstamp

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,29 +43,36 @@ nobase_include_HEADERS = \
 	valhalla/thor/edgestatus.h \
 	valhalla/thor/pathalgorithm.h \
 	valhalla/thor/pathinfo.h \
-	valhalla/thor/trippathbuilder.h 
+	valhalla/thor/trippathbuilder.h \
+	valhalla/thor/service.h
 libvalhalla_thor_la_SOURCES = \
 	src/thor/adjacencylist.cc \
 	src/thor/astarheuristic.cc \
 	src/thor/edgestatus.cc \
 	src/thor/formlocalpath.cc \
 	src/thor/pathalgorithm.cc \
-	src/thor/trippathbuilder.cc 
+	src/thor/trippathbuilder.cc \
+	src/thor/service.cc
 libvalhalla_thor_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-libvalhalla_thor_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ @PROTOC_LIBS@
+libvalhalla_thor_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) @PROTOC_LIBS@
 
 #distributed executables
-bin_PROGRAMS = pathtest \
-               citytest 
-
+bin_PROGRAMS = \
+	pathtest \
+	citytest \
+	thor_service
 pathtest_SOURCES = \
 	src/thor/pathtest/pathtest.cc
 pathtest_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-pathtest_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ -lz libvalhalla_thor.la
+pathtest_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) -lz libvalhalla_thor.la
 citytest_SOURCES = \
 	src/thor/citytest/citytest.cc
 citytest_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
-citytest_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ @BOOST_PROGRAM_OPTIONS_LIB@ @BOOST_FILESYSTEM_LIB@ -lz libvalhalla_thor.la
+citytest_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) -lz libvalhalla_thor.la
+thor_service_SOURCES = \
+        src/thor/thor_service.cc
+thor_service_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_CPPFLAGS) @BOOST_CPPFLAGS@
+thor_service_LDADD = $(DEPS_LIBS) $(VALHALLA_LDFLAGS) @BOOST_LDFLAGS@ $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) -lz libvalhalla_thor.la
 
 # tests
 check_PROGRAMS = \

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ dependencies:
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
     - scripts/install_service_deps.sh
     #valhalla dependencies
-    - cd deps; for dep in midgard baldr sif mjolnir loki odin; do cd $dep; ./autogen.sh && ./configure && sudo make -j4 install; cd ..; done
+    - cd deps; for dep in midgard baldr sif mjolnir loki odin; do cd $dep; ./autogen.sh && ./configure CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE && sudo make -j4 install; cd ..; done
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ checkout:
 dependencies:
   override:
     - sudo apt-get remove --purge -y libboost*
-    - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev lcov protobuf-compiler libprotobuf-dev lua5.2 liblua5.2-dev
+    - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev libboost-thread1.54-dev lcov protobuf-compiler libprotobuf-dev lua5.2 liblua5.2-dev
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
     - scripts/install_service_deps.sh
     #valhalla dependencies

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  environment:
+    LD_LIBRARY_PATH: .:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
   pre:
     - sudo add-apt-repository -y ppa:boost-latest/ppa
     #- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
@@ -16,14 +18,15 @@ dependencies:
     - sudo apt-get remove --purge -y libboost*
     - sudo apt-get install -y autoconf automake libtool make gcc-4.8 g++-4.8 libboost1.54-dev libboost-program-options1.54-dev libboost-filesystem1.54-dev libboost-system1.54-dev lcov protobuf-compiler libprotobuf-dev lua5.2 liblua5.2-dev
     - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+    - scripts/install_service_deps.sh
     #valhalla dependencies
     - cd deps; for dep in midgard baldr sif mjolnir loki odin; do cd $dep; ./autogen.sh && ./configure && sudo make -j4 install; cd ..; done
 
 test:
   pre:
-    - ./autogen.sh && ./configure --enable-coverage --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local --with-valhalla-loki=/usr/local --with-valhalla-odin=/usr/local --with-valhalla-sif=/usr/local --with-valhalla-mjolnir=/usr/local
+    - ./autogen.sh && ./configure --enable-coverage --with-valhalla-midgard=/usr/local --with-valhalla-baldr=/usr/local --with-valhalla-loki=/usr/local --with-valhalla-odin=/usr/local --with-valhalla-sif=/usr/local --with-valhalla-mjolnir=/usr/local CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
   override:
-    - LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib make test -j4
+    - make test -j4
   post:
     - sudo make install
 

--- a/conf/valhalla.json
+++ b/conf/valhalla.json
@@ -15,25 +15,55 @@
       "node_script": "conf/vertices.lua",
       "node_function": "nodes_proc",
       "way_script": "conf/edges.lua",
-      "way_function": "ways_proc"
+      "way_function": "ways_proc",
+      "relation_script": "conf/relations.lua",
+      "relation_function": "rels_proc"
     },
     "logging": {
       "type": "std_out",
       "color": true
     }
   },
+  "loki": {
+    "logging": {
+      "type": "std_out",
+      "color": true
+    },
+    "service": {
+      "proxy": "ipc://loki"
+    }
+  },
   "thor": {
     "logging": {
       "type": "std_out",
       "color": true
+    },
+    "service": {
+      "proxy": "ipc://thor"
     }
   },
-  "tyr": {
-    "listen_address": "0.0.0.0",
-    "port": 8003,
+  "odin": {
     "logging": {
       "type": "std_out",
       "color": true
+    },
+    "service": {
+      "proxy": "ipc://odin"
+    }
+  },
+  "tyr": {
+    "logging": {
+      "type": "std_out",
+      "color": true
+    },
+    "service": {
+      "proxy": "ipc://tyr"
+    }
+  },
+  "httpd": {
+    "service": {
+      "listen": "tcp://*:8002",
+      "loopback": "ipc://loopback"
     }
   },
   "costing_options": {

--- a/configure.ac
+++ b/configure.ac
@@ -35,10 +35,11 @@ CHECK_VALHALLA_ODIN
 AX_BOOST_BASE([1.54], , [AC_MSG_ERROR([cannot find Boost libraries, which are are required for building thor. Please install libboost-dev.])])
 AX_BOOST_PROGRAM_OPTIONS
 AX_BOOST_SYSTEM
+AX_BOOST_THREAD
 AX_BOOST_FILESYSTEM
 
-# check pkg-config packaged packages.
-PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0])
+# check pkg-config dependencies
+PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libzmq >= 4.0 libprime_server >= 0.1.0])
 
 # optionally enable coverage information
 CHECK_COVERAGE

--- a/m4/ax_boost_thread.m4
+++ b/m4/ax_boost_thread.m4
@@ -1,0 +1,149 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BOOST_THREAD
+#
+# DESCRIPTION
+#
+#   Test for Thread library from the Boost C++ libraries. The macro requires
+#   a preceding call to AX_BOOST_BASE. Further documentation is available at
+#   <http://randspringer.de/boost/index.html>.
+#
+#   This macro calls:
+#
+#     AC_SUBST(BOOST_THREAD_LIB)
+#
+#   And sets:
+#
+#     HAVE_BOOST_THREAD
+#
+# LICENSE
+#
+#   Copyright (c) 2009 Thomas Porschberg <thomas@randspringer.de>
+#   Copyright (c) 2009 Michael Tindal
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 27
+
+AC_DEFUN([AX_BOOST_THREAD],
+[
+	AC_ARG_WITH([boost-thread],
+	AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost - it is possible to specify a certain library for the linker
+                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+        [
+        if test "$withval" = "no"; then
+			want_boost="no"
+        elif test "$withval" = "yes"; then
+            want_boost="yes"
+            ax_boost_user_thread_lib=""
+        else
+		    want_boost="yes"
+		ax_boost_user_thread_lib="$withval"
+		fi
+        ],
+        [want_boost="yes"]
+	)
+
+	if test "x$want_boost" = "xyes"; then
+        AC_REQUIRE([AC_PROG_CC])
+        AC_REQUIRE([AC_CANONICAL_BUILD])
+		CPPFLAGS_SAVED="$CPPFLAGS"
+		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+		export CPPFLAGS
+
+		LDFLAGS_SAVED="$LDFLAGS"
+		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+		export LDFLAGS
+
+        AC_CACHE_CHECK(whether the Boost::Thread library is available,
+					   ax_cv_boost_thread,
+        [AC_LANG_PUSH([C++])
+			 CXXFLAGS_SAVE=$CXXFLAGS
+
+			 if test "x$host_os" = "xsolaris" ; then
+				 CXXFLAGS="-pthreads $CXXFLAGS"
+			 elif test "x$host_os" = "xmingw32" ; then
+				 CXXFLAGS="-mthreads $CXXFLAGS"
+			 else
+				CXXFLAGS="-pthread $CXXFLAGS"
+			 fi
+			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
+                                   [[boost::thread_group thrds;
+                                   return 0;]])],
+                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+			 CXXFLAGS=$CXXFLAGS_SAVE
+             AC_LANG_POP([C++])
+		])
+		if test "x$ax_cv_boost_thread" = "xyes"; then
+           if test "x$host_os" = "xsolaris" ; then
+			  BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+		   elif test "x$host_os" = "xmingw32" ; then
+			  BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+		   else
+			  BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+		   fi
+
+			AC_SUBST(BOOST_CPPFLAGS)
+
+			AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
+
+			LDFLAGS_SAVE=$LDFLAGS
+                        case "x$host_os" in
+                          *bsd* )
+                               LDFLAGS="-pthread $LDFLAGS"
+                          break;
+                          ;;
+                        esac
+            if test "x$ax_boost_user_thread_lib" = "x"; then
+                for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                if test "x$link_thread" != "xyes"; then
+                for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
+                     ax_lib=${libextension}
+				    AC_CHECK_LIB($ax_lib, exit,
+                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                 [link_thread="no"])
+				done
+                fi
+
+            else
+               for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
+				      AC_CHECK_LIB($ax_lib, exit,
+                                   [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                                   [link_thread="no"])
+                  done
+
+            fi
+            if test "x$ax_lib" = "x"; then
+                AC_MSG_ERROR(Could not find a version of the library!)
+            fi
+			if test "x$link_thread" = "xno"; then
+				AC_MSG_ERROR(Could not link against $ax_lib !)
+                        else
+                           case "x$host_os" in
+                              *bsd* )
+				BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                              break;
+                              ;;
+                           esac
+
+			fi
+		fi
+
+		CPPFLAGS="$CPPFLAGS_SAVED"
+	LDFLAGS="$LDFLAGS_SAVED"
+	fi
+])

--- a/scripts/install_service_deps.sh
+++ b/scripts/install_service_deps.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# grab the latest zmq library:
+git clone --depth=1 --recurse-submodules --single-branch --branch=master https://github.com/zeromq/libzmq.git
+pushd libzmq
+./autogen.sh && ./configure --without-libsodium --without-documentation && make -j4
+sudo make install
+popd
+rm -rf libzmq
+
+# grab experimental zmq-based server API:
+git clone --depth=1 --recurse-submodules --single-branch --branch=master https://github.com/kevinkreiser/prime_server.git
+pushd prime_server
+./autogen.sh && ./configure && make test -j4
+sudo make install
+popd
+rm -rf prime_server

--- a/src/thor/service.cc
+++ b/src/thor/service.cc
@@ -1,0 +1,171 @@
+#include <functional>
+#include <string>
+#include <stdexcept>
+#include <vector>
+#include <unordered_map>
+#include <cstdint>
+#include <sstream>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/info_parser.hpp>
+
+#include <prime_server/prime_server.hpp>
+#include <prime_server/http_protocol.hpp>
+using namespace prime_server;
+
+#include <valhalla/midgard/logging.h>
+#include <valhalla/baldr/json.h>
+#include <valhalla/baldr/location.h>
+#include <valhalla/baldr/pathlocation.h>
+#include <valhalla/baldr/graphreader.h>
+#include <valhalla/sif/costfactory.h>
+#include <valhalla/sif/autocost.h>
+#include <valhalla/sif/bicyclecost.h>
+#include <valhalla/sif/pedestriancost.h>
+
+#include "thor/service.h"
+#include "thor/trippathbuilder.h"
+#include "thor/pathalgorithm.h"
+
+using namespace valhalla;
+using namespace valhalla::midgard;
+using namespace valhalla::baldr;
+using namespace valhalla::sif;
+
+
+namespace {
+  //TODO: throw this in the header to make it testable?
+  class thor_worker_t {
+   public:
+    thor_worker_t(const boost::property_tree::ptree& config):config(config),
+    origin(PointLL()), destination(PointLL()), reader(config.get_child("mjolnir.hierarchy")) {
+      // Register edge/node costing methods
+      factory.Register("auto", sif::CreateAutoCost);
+      factory.Register("auto_shorter", sif::CreateAutoShorterCost);
+      factory.Register("bicycle", sif::CreateBicycleCost);
+      factory.Register("pedestrian", sif::CreatePedestrianCost);
+    }
+    worker_t::result_t work(const std::list<zmq::message_t>& job, void* request_info) {
+      try{
+        //get some info about what we need to do
+        std::string request_str(static_cast<const char*>(job.front().data()), job.front().size());
+        std::stringstream stream(request_str);
+        boost::property_tree::ptree request;
+        boost::property_tree::read_info(stream, request);
+        init_request(request);
+
+        //find a path
+        auto path_edges = path_algorithm.GetBestPath(origin, destination, reader, cost);
+        if (path_edges.size() == 0) {
+          if (cost->AllowMultiPass()) {
+            LOG_INFO("Try again with relaxed hierarchy limits");
+            path_algorithm.Clear();
+            cost->RelaxHierarchyLimits(16.0f);
+            path_edges = path_algorithm.GetBestPath(origin, destination, reader, cost);
+          }
+        }
+        if (path_edges.size() == 0) {
+          cost->DisableHighwayTransitions();
+          path_edges = path_algorithm.GetBestPath(origin, destination, reader, cost);
+          if (path_edges.size() == 0) {
+            throw std::runtime_error("No path could be found for input");
+          }
+        }
+
+        // Form output information based on path edges
+        auto trip_path = thor::TripPathBuilder::Build(reader, path_edges, origin, destination);
+        path_algorithm.Clear();
+        locations.clear();
+
+        //pass it on
+        worker_t::result_t result{true};
+        result.messages.emplace_back(std::move(request_str)); //the original request
+        result.messages.emplace_back(trip_path.SerializeAsString()); //the protobuf path
+        return result;
+      }
+      catch(const std::exception& e) {
+        worker_t::result_t result{false};
+        http_response_t response(400, "Bad Request", e.what());
+        response.from_info(static_cast<http_request_t::info_t*>(request_info));
+        result.messages.emplace_back(response.to_string());
+        return result;
+      }
+    }
+    void init_request(const boost::property_tree::ptree& request) {
+      //we require locations
+      try {
+        for(const auto& location : request.get_child("locations"))
+          locations.push_back(baldr::Location::FromPtree(location.second));
+        if(locations.size() < 2)
+          throw;
+        //TODO: bail if this is too many
+      }
+      catch(...) {
+        throw std::runtime_error("insufficiently specified required parameter 'locations'");
+      }
+
+      //we require correlated locations
+      try {
+        auto origin_pt = request.get_child("origin");
+        origin = PathLocation::FromPtree(locations, origin_pt);
+        auto destination_pt = request.get_child("destination");
+        destination = PathLocation::FromPtree(locations, destination_pt);
+      }
+      catch(...) {
+        throw std::runtime_error("path computation requires graph correlated locations");
+      }
+
+      // Parse out the type of route - this provides the costing method to use
+      std::string costing;
+      try {
+        costing = request.get<std::string>("costing");
+      }
+      catch(...) {
+        throw std::runtime_error("No edge/node costing provided");
+      }
+
+      // Get the costing options. Get the base options from the config and the
+      // options for the specified costing method
+      std::string method_options = "costing_options." + costing;
+      boost::property_tree::ptree config_costing = config.get_child(method_options);
+      const auto& request_costing = request.get_child_optional(method_options);
+      if (request_costing) {
+        // If the request has any options for this costing type, merge the 2
+        // costing options - override any config options that are in the request.
+        // and add any request options not in the config.
+        for (const auto& r : *request_costing) {
+          config_costing.put_child(r.first, r.second);
+        }
+      }
+      cost = factory.Create(costing, config_costing);
+    }
+   protected:
+    boost::property_tree::ptree config;
+    std::vector<Location> locations;
+    PathLocation origin, destination;
+    sif::CostFactory<sif::DynamicCost> factory;
+    valhalla::sif::cost_ptr_t cost;
+    valhalla::baldr::GraphReader reader;
+    valhalla::thor::PathAlgorithm path_algorithm;
+  };
+}
+
+namespace valhalla {
+  namespace thor {
+    void run_service(const boost::property_tree::ptree& config) {
+      //gets requests from thor proxy
+      auto upstream_endpoint = config.get<std::string>("thor.service.proxy") + "_out";
+      //sends them on to odin
+      auto downstream_endpoint = config.get<std::string>("odin.service.proxy") + "_in";
+      //or returns just location information back to the server
+      auto loopback_endpoint = config.get<std::string>("httpd.service.loopback");
+
+      //listen for requests
+      zmq::context_t context;
+      prime_server::worker_t worker(context, upstream_endpoint, downstream_endpoint, loopback_endpoint,
+        std::bind(&thor_worker_t::work, thor_worker_t(config), std::placeholders::_1, std::placeholders::_2));
+      worker.work();
+
+      //TODO: should we listen for SIGINT and terminate gracefully/exit(0)?
+    }
+  }
+}

--- a/src/thor/thor_service.cc
+++ b/src/thor/thor_service.cc
@@ -1,0 +1,24 @@
+#include <iostream>
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+
+#include "thor/service.h"
+
+int main(int argc, char** argv) {
+
+  if(argc < 2) {
+    std::cerr << "Usage: " << std::string(argv[0]) << " conf/valhalla.json" << std::endl;
+    return 1;
+  }
+
+  //config file
+  std::string config_file(argv[1]);
+  boost::property_tree::ptree config;
+  boost::property_tree::read_json(config_file, config);
+
+  //run the service worker
+  valhalla::thor::run_service(config);
+
+  return 0;
+}

--- a/valhalla/thor/service.h
+++ b/valhalla/thor/service.h
@@ -1,0 +1,15 @@
+#ifndef __VALHALLA_THOR_SERVICE_H__
+#define __VALHALLA_THOR_SERVICE_H__
+
+#include <boost/property_tree/ptree.hpp>
+
+namespace valhalla {
+  namespace thor {
+
+    void run_service(const boost::property_tree::ptree& config);
+
+  }
+}
+
+
+#endif //__VALHALLA_THOR_SERVICE_H__


### PR DESCRIPTION
two things are added here, a binary that makes use of the thor service layer code, and the thor service layer code with is part of the thor library. it makes use of all the prime_server zmq deps but its part of the library so the simple server in tyr can just use it. this way the same code will be run regardless of in production or testing on our local machines

for thor it was really straight forward, grab some info out of the request that loki passes on to us. run the route, serialize the protobuf bytes (and the original request) onto odin.