### PR TITLE
Stastics for pathtest 

### DIFF
--- a/scripts/batch.sh
+++ b/scripts/batch.sh
@@ -57,8 +57,15 @@ sed -i -e "s/\([^\\]\)'|/\1|/g" -e "s/|'/|/g" "${TMP}"
 #from the log messages otherwise every line will be a diff
 #TODO: add leading zeros to output files so they sort nicely
 echo -e "\x1b[32;1mWriting routes from ${INPUT} with a concurrency of ${CONCURRENCY} into ${OUTDIR}\x1b[0m"
-cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "pathtest {} 2>&1 | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' &> ${OUTDIR}/{#}.txt"
+cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "pathtest {} > ${OUTDIR}/{#}.txt"
 rm -f "${TMP}"
+
+for FN in $(ls ${OUTDIR}); do
+  cat ${OUTDIR}/${FN} | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' > ${OUTDIR}/narr_${FN}
+  cat ${OUTDIR}/${FN} | grep -F STATISTICS | sed -e 's/^[^\[]*\[STATISTICS\] //' > ${OUTDIR}/stat_${FN}
+  cat ${OUTDIR}/${FN} | grep -F STATISTICS | sed -e 's/^[^\[]*\[STATISTICS\] //' >> ${OUTDIR}/STATISTICS.csv
+  rm ${OUTDIR}/${FN}
+done
 
 #if we need to run a diff
 if [ -d "${DIFF}" ]; then

--- a/scripts/batch.sh
+++ b/scripts/batch.sh
@@ -57,15 +57,10 @@ sed -i -e "s/\([^\\]\)'|/\1|/g" -e "s/|'/|/g" "${TMP}"
 #from the log messages otherwise every line will be a diff
 #TODO: add leading zeros to output files so they sort nicely
 echo -e "\x1b[32;1mWriting routes from ${INPUT} with a concurrency of ${CONCURRENCY} into ${OUTDIR}\x1b[0m"
-cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "pathtest {} > ${OUTDIR}/{#}.txt"
+cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "pathtest {} 2>&1 | tee -a ${OUTDIR}/statistics.tmp | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' &> ${OUTDIR}/{#}.txt"
 rm -f "${TMP}"
-
-for FN in $(ls ${OUTDIR}); do
-  cat ${OUTDIR}/${FN} | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' > ${OUTDIR}/narr_${FN}
-  cat ${OUTDIR}/${FN} | grep -F STATISTICS | sed -e 's/^[^\[]*\[STATISTICS\] //' > ${OUTDIR}/stat_${FN}
-  cat ${OUTDIR}/${FN} | grep -F STATISTICS | sed -e 's/^[^\[]*\[STATISTICS\] //' >> ${OUTDIR}/STATISTICS.csv
-  rm ${OUTDIR}/${FN}
-done
+cat ${OUTDIR}/statistics.tmp | grep -F STATISTICS | sed -e 's/^[^\[]*\[STATISTICS\] //' &> ${OUTDIR}/statistics.csv
+rm ${OUTDIR}/statistics.tmp
 
 #if we need to run a diff
 if [ -d "${DIFF}" ]; then

--- a/src/thor/pathtest/pathtest.cc
+++ b/src/thor/pathtest/pathtest.cc
@@ -36,12 +36,49 @@ using namespace valhalla::thor;
 namespace bpo = boost::program_options;
 
 typedef std::tuple<float, float, float, float, bool, uint32_t, uint32_t, uint32_t, float, float, int> CSV_STATS;
+
+namespace {
+  class PathStatistics {
+    std::pair<float, float> origin;
+    std::pair<float, float> destination;
+    bool success;
+    uint32_t passes;
+    uint32_t runtime;
+    uint32_t trip_time;
+    float trip_dist;
+    float arc_dist;
+    uint32_t manuevers;
+
+  public:
+    PathStatistics (std::pair<float, float> p1, std::pair<float, float> p2)
+      : origin(p1), destination(p2), success(false),
+        passes(0), runtime(), trip_time(),
+        trip_dist(), arc_dist(), manuevers() { }
+
+    void setSuccess(bool b) { success = b; }
+    void incPasses(void) { ++passes; }
+    void addRuntime(uint32_t msec) { runtime += msec; }
+    void setTripTime(uint32_t t) { trip_time = t; }
+    void setTripDist(float d) { trip_dist = d; }
+    void setArcDist(float d) { arc_dist = d; }
+    void setManuevers(uint32_t n) { manuevers = n; }
+    void log() {
+      std::string successStr = (success) ? "true" : "false";
+      valhalla::midgard::logging::Log(
+        (boost::format("%f,%f,%f,%f,%s,%d,%d,%d,%f,%f,%d")
+          % origin.first % origin.second % destination.first % destination.second
+          % successStr % passes % runtime % trip_time % trip_dist % arc_dist % manuevers).str(),
+        " [STATISTICS] ");
+    }
+  };
+}
+
 /**
  * Test a single path from origin to destination.
  */
 TripPath PathTest(GraphReader& reader, const PathLocation& origin,
                   const PathLocation& dest, std::shared_ptr<DynamicCost> cost,
-                  CSV_STATS& csv_data) {
+                  PathStatistics& data) {
   auto t1 = std::chrono::high_resolution_clock::now();
   PathAlgorithm pathalgorithm;
   auto t2 = std::chrono::high_resolution_clock::now();
@@ -51,20 +88,20 @@ TripPath PathTest(GraphReader& reader, const PathLocation& origin,
   t1 = std::chrono::high_resolution_clock::now();
   std::vector<PathInfo> pathedges;
   pathedges = pathalgorithm.GetBestPath(origin, dest, reader, cost);
-  std::get<5>(csv_data) = 1;
+  data.incPasses();
   if (pathedges.size() == 0) {
     if (cost->AllowMultiPass()) {
       LOG_INFO("Try again with relaxed hierarchy limits");
       pathalgorithm.Clear();
       cost->RelaxHierarchyLimits(16.0f);
       pathedges = pathalgorithm.GetBestPath(origin, dest, reader, cost);
-      std::get<5>(csv_data)++;
+      data.incPasses();
     }
   }
   if (pathedges.size() == 0) {
     cost->DisableHighwayTransitions();
     pathedges = pathalgorithm.GetBestPath(origin, dest, reader, cost);
-    std::get<5>(csv_data)++;
+    data.incPasses();
     if (pathedges.size() == 0) {
       throw std::runtime_error("No path could be found for input");
     }
@@ -207,7 +244,7 @@ std::string GetFormattedTime(uint32_t seconds) {
 
 TripDirections DirectionsTest(const DirectionsOptions& directions_options,
                               TripPath& trip_path, Location origin,
-                              Location destination, CSV_STATS& csv_data) {
+                              Location destination, PathStatistics& data) {
   DirectionsBuilder directions;
   TripDirections trip_directions = directions.Build(directions_options,
                                                     trip_path);
@@ -241,37 +278,11 @@ TripDirections DirectionsTest(const DirectionsOptions& directions_options,
       (boost::format("Total length: %.1f %s")
           % trip_directions.summary().length() % units).str(),
       " [NARRATIVE] ");
-  std::get<7>(csv_data) = trip_directions.summary().time();
-  std::get<8>(csv_data) = trip_directions.summary().length();
-  std::get<10>(csv_data) = trip_directions.maneuver_size();
+  data.setTripTime(trip_directions.summary().time());
+  data.setTripDist(trip_directions.summary().length());
+  data.setManuevers(trip_directions.maneuver_size());
 
   return trip_directions;
-}
-
-void log_csv(CSV_STATS& csv_data) {
-  std::string line = std::to_string(std::get<0>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<1>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<2>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<3>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<4>(csv_data));
-  line += ",";
-  line += (std::get<5>(csv_data)) ? "true" : "false";
-  line += ",";
-  line += std::to_string(std::get<6>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<7>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<8>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<9>(csv_data));
-  line += ",";
-  line += std::to_string(std::get<10>(csv_data));
-
-  valhalla::midgard::logging::Log(line, " [STATISTICS] ");
 }
 
 // Main method for testing a single path
@@ -419,16 +430,11 @@ int main(int argc, char *argv[]) {
     valhalla::midgard::logging::Configure(logging_config);
   }
 
-  // Something to hold all the stats
-  // INDEX  0       1       2       3       4       5       6       7         8       9           10
-  // STAT   orgLat  orgLng  destLat destLng success #Passes runtime trip time length  arcDistance #Manuevers
+  //Something to hold the statistics
   CSV_STATS csv_data;
-  std::get<0>(csv_data) = originloc.latlng_.lat();
-  std::get<1>(csv_data) = originloc.latlng_.lng();
-  std::get<2>(csv_data) = destloc.latlng_.lat();
-  std::get<3>(csv_data) = destloc.latlng_.lng();
-  std::get<9>(csv_data) = sqrt(DistanceApproximator::DistanceSquared(originloc.latlng_, destloc.latlng_)) / 1000;
-
+  PathStatistics data({originloc.latlng_.lat(), originloc.latlng_.lng()},
+                      {destloc.latlng_.lat(), destloc.latlng_.lng()});
+  data.setArcDist(sqrt(DistanceApproximator::DistanceSquared(originloc.latlng_, destloc.latlng_)) / 1000);
 
   // Get something we can use to fetch tiles
   valhalla::baldr::GraphReader reader(pt.get_child("mjolnir.hierarchy"));
@@ -441,15 +447,15 @@ int main(int argc, char *argv[]) {
   auto t10 = std::chrono::high_resolution_clock::now();
   if (!reader.AreConnected({origin_tile, local_level, 0}, {dest_tile, local_level, 0})) {
     LOG_INFO("No tile connectivity between origin and destination.");
-    std::get<4>(csv_data) = false;
-    log_csv(csv_data);
+    data.setSuccess(false);
+    data.log();
     return EXIT_SUCCESS;
   }
   auto t20 = std::chrono::high_resolution_clock::now();
   uint32_t msecs1 =
          std::chrono::duration_cast<std::chrono::milliseconds>(t20 - t10).count();
   LOG_INFO("Tile CoverageMap took " + std::to_string(msecs1) + " ms");
-  std::get<6>(csv_data) = msecs1;
+  data.addRuntime(msecs1);
 
   // Construct costing
   CostFactory<DynamicCost> factory;
@@ -514,29 +520,29 @@ int main(int argc, char *argv[]) {
     uint32_t msecs = std::chrono::duration_cast<std::chrono::milliseconds>(
         t2 - t1).count();
     LOG_INFO("Location Processing took " + std::to_string(msecs) + " ms");
-    std::get<6>(csv_data) += msecs;
+    data.addRuntime(msecs);
 
     // Get the route
     t1 = std::chrono::high_resolution_clock::now();
-    trip_path = PathTest(reader, pathOrigin, pathDest, cost, csv_data);
+    trip_path = PathTest(reader, pathOrigin, pathDest, cost, data);
     t2 = std::chrono::high_resolution_clock::now();
     msecs =
         std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     LOG_INFO("PathTest took " + std::to_string(msecs) + " ms");
-    std::get<6>(csv_data) += msecs;
+    data.addRuntime(msecs);
   }
 
   // Try the the directions
   auto t1 = std::chrono::high_resolution_clock::now();
   TripDirections trip_directions = DirectionsTest(directions_options, trip_path,
-                                                  originloc, destloc, csv_data);
+                                                  originloc, destloc, data);
   auto t2 = std::chrono::high_resolution_clock::now();
   uint32_t msecs =
       std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
   LOG_INFO("TripDirections took " + std::to_string(msecs) + " ms");
-  std::get<6>(csv_data) += msecs;
-  std::get<4>(csv_data) = true;
-  log_csv(csv_data);
+  data.addRuntime(msecs);
+  data.setSuccess(true);
+  data.log();
 
   return EXIT_SUCCESS;
 }

--- a/src/thor/pathtest/pathtest.cc
+++ b/src/thor/pathtest/pathtest.cc
@@ -35,8 +35,6 @@ using namespace valhalla::thor;
 
 namespace bpo = boost::program_options;
 
-typedef std::tuple<float, float, float, float, bool, uint32_t, uint32_t, uint32_t, float, float, int> CSV_STATS;
-
 namespace {
   class PathStatistics {
     std::pair<float, float> origin;
@@ -431,7 +429,6 @@ int main(int argc, char *argv[]) {
   }
 
   //Something to hold the statistics
-  CSV_STATS csv_data;
   PathStatistics data({originloc.latlng_.lat(), originloc.latlng_.lng()},
                       {destloc.latlng_.lat(), destloc.latlng_.lng()});
   data.setArcDist(sqrt(DistanceApproximator::DistanceSquared(originloc.latlng_, destloc.latlng_)) / 1000);


### PR DESCRIPTION
Now when pathtest is run some statistics about the route are gathered. They are logged after the narrative and when pathtest is run using batch.sh the statistical output from each path is saved to statistics.csv

The various fields in the csv are as follows:
orgLat, orgLng, destLat, destLng, success, #Passes, runtime, trip time, length, arcDistance, #Manuevers