### PR TITLE
Add an Update method for EdgeStatus.

### DIFF
--- a/src/thor/edgestatus.cc
+++ b/src/thor/edgestatus.cc
@@ -20,6 +20,11 @@ void EdgeStatus::Set(const baldr::GraphId& edgeid,
   edgestatus_[edgeid] = { set, index };
 }
 
+// Update the edge status of a GraphId
+void EdgeStatus::Update(const baldr::GraphId& edgeid, const EdgeSet set) {
+  edgestatus_[edgeid].status.set = set;
+}
+
 // Get the edge status of a GraphId. If not found in the map the
 // edge is considered unreached.
 EdgeStatusInfo EdgeStatus::Get(const baldr::GraphId& edgeid) const {

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -86,7 +86,7 @@ std::vector<PathInfo> PathAlgorithm::GetBestPathMM(const PathLocation& origin,
     // Remove label from adjacency list, mark it as done - copy the EdgeLabel
     // for use in costing
     EdgeLabel pred = edgelabels_[predindex];
-    edgestatus_->Set(pred.edgeid(), kPermanent, pred.edgeid());
+    edgestatus_->Update(pred.edgeid(), kPermanent);
 
     // Check that distance is converging towards the destination. Return route
     // failure if no convergence for TODO iterations

--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -242,7 +242,7 @@ std::vector<PathInfo> PathAlgorithm::GetBestPath(const PathLocation& origin,
     // Remove label from adjacency list, mark it as permanently labeled.
     // Copy the EdgeLabel for use in costing
     EdgeLabel pred = edgelabels_[predindex];
-    edgestatus_->Set(pred.edgeid(), kPermanent, pred.edgeid());
+    edgestatus_->Update(pred.edgeid(), kPermanent);
 
     // Check that distance is converging towards the destination. Return route
     // failure if no convergence for TODO iterations

--- a/valhalla/thor/edgestatus.h
+++ b/valhalla/thor/edgestatus.h
@@ -61,6 +61,13 @@ class EdgeStatus {
            const uint32_t index);
 
   /**
+   * Update the status of a directed edge given its GraphId.
+   * @param  edgeid   GraphId of the directed edge to set.
+   * @param  set      Label set for this directed edge.
+   */
+  void Update(const baldr::GraphId& edgeid, const EdgeSet set);
+
+  /**
    * Get the status info of a directed edge given its GraphId.
    * @param   edgeid  GraphId of the directed edge.
    * @return  Returns edge status info.


### PR DESCRIPTION
Calling Set again was corrupting the index. This didn't matter with forward A*, but need to retain the index in bidirectional A*.