### PR TITLE
Use mode from costing

### DIFF
--- a/src/thor/citytest/citytest.cc
+++ b/src/thor/citytest/citytest.cc
@@ -253,18 +253,12 @@ int main(int argc, char *argv[]) {
       // Get the costing method. We do this each time since prior route may
       // have changed hierarchy_limits. Also, this simulates how the service
       // works
-      TravelMode mode;
       cost_ptr_t mode_costing[4];
-      if (routetype == "auto" || routetype == "bus") {
-        mode = valhalla::sif::TravelMode::kDrive;
-      } else if (routetype == "bicycle") {
-        mode = valhalla::sif::TravelMode::kBicycle;
-      } else {
-        mode = valhalla::sif::TravelMode::kPedestrian;
-      }
-      mode_costing[static_cast<uint32_t>(mode)] = factory.Create(
-              routetype, pt.get_child("costing_options." + routetype));
-      cost_ptr_t cost = mode_costing[static_cast<uint32_t>(mode)];
+      cost_ptr_t cost = factory.Create(
+          routetype, pt.get_child("costing_options." + routetype));
+      TravelMode mode = cost->travelmode();
+      mode_costing[static_cast<uint32_t>(mode)] = cost;
+
 
       Location originloc(cities[l0].latlng);
       Location destloc(cities[l1].latlng);

--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -250,6 +250,8 @@ std::vector<PathInfo> PathAlgorithm::GetBestPath(const PathLocation& origin,
       mindist = dist2dest;
       nc = 0;
     } else if (nc++ > 500000) {
+      LOG_ERROR("No convergence to destination after = " +
+                           std::to_string(edgelabels_.size()));
       return {};
     }
 

--- a/src/thor/service.cc
+++ b/src/thor/service.cc
@@ -194,15 +194,9 @@ namespace {
         mode_costing[3] = get_costing(request, "transit");
         mode = valhalla::sif::TravelMode::kPedestrian;
       } else {
-        // Construct just the requested costing model
-        if (costing == "auto" || costing == "bus") {
-          mode = valhalla::sif::TravelMode::kDrive;
-        } else if (costing == "bicycle") {
-          mode = valhalla::sif::TravelMode::kBicycle;
-        } else {
-          mode = valhalla::sif::TravelMode::kPedestrian;
-        }
-        mode_costing[static_cast<uint32_t>(mode)] = get_costing(request, costing);
+        valhalla::sif::cost_ptr_t cost = get_costing(request, costing);
+        mode = cost->travelmode();
+        mode_costing[static_cast<uint32_t>(mode)] = cost;
       }
       return costing;
     }

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -252,10 +252,6 @@ class MultiModalPathAlgorithm : public PathAlgorithm {
            const std::shared_ptr<sif::DynamicCost>* mode_costing,
            const sif::TravelMode mode);
 
-  std::string Type() {
-    return "Multimodal A*";
-  }
-
  protected:
 
   /**


### PR DESCRIPTION
Simplify assignment of mode.
Update pathtest to store correct elapsed time on failure. List destinations to see if marked as unreachable.
Log failures due to non-convergence towards destination.