### PR TITLE
Added failure cases to pathtest to provide better detail

### DIFF
--- a/scripts/batch.sh
+++ b/scripts/batch.sh
@@ -59,7 +59,8 @@ sed -i -e "s/\([^\\]\)'|/\1|/g" -e "s/|'/|/g" "${TMP}"
 echo -e "\x1b[32;1mWriting routes from ${INPUT} with a concurrency of ${CONCURRENCY} into ${OUTDIR}\x1b[0m"
 cat "${TMP}" | parallel --progress -k -C '\|' -P "${CONCURRENCY}" "pathtest {} 2>&1 | tee -a ${OUTDIR}/statistics.tmp | grep -F NARRATIVE | sed -e 's/^[^\[]*\[NARRATIVE\] //' &> ${OUTDIR}/{#}.txt"
 rm -f "${TMP}"
-cat ${OUTDIR}/statistics.tmp | grep -F STATISTICS | sed -e 's/^[^\[]*\[STATISTICS\] //' &> ${OUTDIR}/statistics.csv
+echo "orgLat, orgLng, destLat, destLng, result, #Passes, runtime, trip time, length, arcDistance, #Manuevers" > ${OUTDIR}/statistics.csv
+cat ${OUTDIR}/statistics.tmp | grep -F STATISTICS | sed -e 's/^[^\[]*\[STATISTICS\] //' &>> ${OUTDIR}/statistics.csv
 rm ${OUTDIR}/statistics.tmp
 echo ${OUTDIR} > outdir.txt
 

--- a/scripts/run_city_routes.sh
+++ b/scripts/run_city_routes.sh
@@ -9,5 +9,4 @@ do
   rm outdir.txt
 done
 
-rm OUTDIRS.txt
 exit

--- a/scripts/run_city_routes.sh
+++ b/scripts/run_city_routes.sh
@@ -9,4 +9,5 @@ do
   rm outdir.txt
 done
 
+rm OUTDIRS.txt
 exit

--- a/src/thor/pathtest/pathtest.cc
+++ b/src/thor/pathtest/pathtest.cc
@@ -552,7 +552,7 @@ int main(int argc, char *argv[]) {
     t2 = std::chrono::high_resolution_clock::now();
     msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     LOG_INFO("TripDirections took " + std::to_string(msecs) + " ms");
-    data.setSuccess("pass");
+    data.setSuccess("success");
   } else {
     // Route was unsuccessful
     data.setSuccess("fail_no_route");

--- a/src/thor/pathtest/pathtest.cc
+++ b/src/thor/pathtest/pathtest.cc
@@ -456,7 +456,7 @@ int main(int argc, char *argv[]) {
     auto t10 = std::chrono::high_resolution_clock::now();
     if (!reader.AreConnected({origin_tile, local_level, 0}, {dest_tile, local_level, 0})) {
       LOG_INFO("No tile connectivity between origin and destination.");
-      data.setSuccess("no_connectivity");
+      data.setSuccess("fail_no_connectivity");
       data.log();
       return EXIT_SUCCESS;
     }
@@ -524,8 +524,17 @@ int main(int argc, char *argv[]) {
   // For now assume pedestrian mode at origin and destination
   auto t1 = std::chrono::high_resolution_clock::now();
   std::shared_ptr<DynamicCost> cost = mode_costing[static_cast<uint32_t>(mode)];
-  PathLocation pathOrigin = Search(originloc, reader, cost->GetFilter());
-  PathLocation pathDest = Search(destloc, reader, cost->GetFilter());
+  auto getPathLoc = [&reader, &cost, &data] (Location& loc, std::string status) {
+    try {
+      return Search(loc, reader, cost->GetFilter());
+    } catch (...) {
+      data.setSuccess(status);
+      data.log();
+      exit(EXIT_FAILURE);
+    }
+  };
+  PathLocation pathOrigin = getPathLoc(originloc, "fail_invalid_origin");
+  PathLocation pathDest = getPathLoc(destloc, "fail_invalid_dest");
   auto t2 = std::chrono::high_resolution_clock::now();
   uint32_t msecs = std::chrono::duration_cast<std::chrono::milliseconds>(
                   t2 - t1).count();
@@ -543,11 +552,10 @@ int main(int argc, char *argv[]) {
     t2 = std::chrono::high_resolution_clock::now();
     msecs = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
     LOG_INFO("TripDirections took " + std::to_string(msecs) + " ms");
-    data.setSuccess("true");
+    data.setSuccess("pass");
   } else {
     // Route was unsuccessful
-    data.setSuccess("false");
-
+    data.setSuccess("fail_no_route");
     // Check if destinations are unreachable
     for (auto& edge : pathDest.edges()) {
       const GraphTile* tile = reader.GetGraphTile(edge.id);


### PR DESCRIPTION
Possible status cases are:
* __success__ - occurs when route is successful
* __fail_no_route__ - occurs when no route can be found
* __fail_no_connectivity__ - occurs when there is no tile connectivity between origin and destination _only_ if the `--connectivity` flag is passed to pathtest
* __fail_invalid_origin__ - occurs when Loki cannot process origin 
* __fail_invalid_dest__ - occurs when Loki cannot process destination

The statistics.csv file generated by batch.sh now contains a header to help identify values.