### PR TITLE
Add logic to handle trivial edge case and "around the block" case.

### DIFF
--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -192,6 +192,8 @@ class TimeDistanceMatrix : public PathAlgorithm {
   /**
    * Update destinations along an edge that has been settled (lowest cost path
    * found to the end of edge).
+   * @param   origin_index  Index of the origin location.
+   * @param   locations     List of locations.
    * @param   destinations  Vector of destination indexes along this edge.
    * @param   edge          Directed edge
    * @param   pred          Predecessor information in shortest path.
@@ -199,7 +201,9 @@ class TimeDistanceMatrix : public PathAlgorithm {
    * @param   costing       Costing method.
    * @return  Returns true if all destinations have been settled.
    */
-  bool UpdateDestinations(std::vector<uint32_t>& destinations,
+  bool UpdateDestinations(const uint32_t origin_index,
+                          const std::vector<baldr::PathLocation>& locations,
+                          std::vector<uint32_t>& destinations,
                           const baldr::DirectedEdge* edge,
                           const sif::EdgeLabel& pred,
                           const uint32_t predindex,


### PR DESCRIPTION
Addresses issue #243.
This test exercises the one to many logic with 2 destinations along the same edge as the origin (one before and one after along the oneway edge):

./timedistance_test --json '{"locations":[{"lat":40.038288,"lon":-76.302389},{"lat":40.038204,"lon":-76.303103},{"lat":40.046568,"lon":-76.296479},{"lat":40.027860,"lon":-76.291404},{"lat":40.038389,"lon":-76.301674}],"costing":"auto"}' --config ./conf/planet.json
