### PR TITLE
Do not enter not_thru regions in reverse search. 

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -347,9 +347,11 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
         }
         GraphId oppedge = GetOpposingEdgeId(directededge, t2);
 
-        // Get opposing directed edge and check if allowed
+        // Get opposing directed edge and check if allowed. Do not enter
+        // not_thru edges
         const DirectedEdge* opp_edge = t2->directededge(oppedge);
-        if (!costing->AllowedReverse(directededge, pred2, opp_edge, opp_pred_edge)) {
+        if (directededge->not_thru() ||
+            !costing->AllowedReverse(directededge, pred2, opp_edge, opp_pred_edge)) {
           continue;
         }
 


### PR DESCRIPTION
Could not do this within costing since many_to-one would not enter any not_thru regions which a valid origin might reside. This change in conjunction with the sif costing changes effectively results in the same logic.