### PR TITLE
Separate turn cost in the reverse path. 

### DIFF
--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -130,10 +130,12 @@ class BidirectionalAStar : public PathAlgorithm {
     * @param  idx        Index into the edge status list.
     * @param  predindex  Index of the predecessor edge.
     * @param  newcost    Cost of the new path.
+    * @param  tc         Turn cost for this transition.
     */
    void CheckIfLowerCostPathReverse(const uint32_t idx,
                              const uint32_t predindex,
-                             const sif::Cost& newcost);
+                             const sif::Cost& newcost,
+                             const sif::Cost& tc);
 
    /**
     * Handle transition edges. Will add any that are allowed to the


### PR DESCRIPTION
Apply this to the elapsed time logic in FormPath so the turn cost applies to the correct node. Also look for either temporary or permanently labelled edges when forming candidate connections - this fixes some connections (especially where the paths are in not_thru regions). Add special case logic to FormPath if the forward path connects to a destination edge (can happen when both locations are within the same not-thru region).