### PR TITLE
added costing for operators

### DIFF
--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -245,27 +245,28 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
           // Add transfer cost. There is no cost if continuing along the
           // same trip Id or (valid) block Id.
           if (tripid != pred.tripid() ||
-             (blockid != 0 && blockid != pred.blockid())) {
+              (blockid != 0 && blockid != pred.blockid())) {
             newcost += transfer_cost;
-          }
 
-          const TransitRoute* transit_route = tile->GetTransitRoute(
-              departure->routeid());
+            const TransitRoute* transit_route = tile->GetTransitRoute(
+                departure->routeid());
 
-          //operator diff
-          if (transit_route && transit_route->op_by_onestop_id_offset()) {
-            std::string id = tile->GetName(transit_route->op_by_onestop_id_offset());
+            //operator diff
+            if (transit_route && transit_route->op_by_onestop_id_offset()) {
+              std::string id = tile->GetName(transit_route->op_by_onestop_id_offset());
 
-            if (onestop_id.empty()) //first pass.
-              onestop_id = id;
+              if (onestop_id.empty()) //first pass.
+                onestop_id = id;
 
-            if (onestop_id != id) {
-              Cost tc = transfer_cost;
-              tc.cost *= 1.5f;
-              newcost += tc;
-              onestop_id = id;
+              if (onestop_id != id) {
+                Cost tc = transfer_cost;
+                tc.cost *= 1.5f;
+                newcost += tc;
+                onestop_id = id;
+              }
             }
           }
+
           // Change mode and costing to transit. Add edge cost.
           mode_ = TravelMode::kPublicTransit;
           newcost += tc->EdgeCost(directededge, departure, localtime);

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -96,6 +96,7 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
   uint32_t blockid, tripid, prior_stop;
   uint32_t nc = 0;       // Count of iterations with no convergence
                          // towards destination
+  std::string onestop_id;
   const GraphTile* tile;
   while (true) {
     // Get next element from adjacency list. Check that it is valid. An
@@ -248,6 +249,23 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
             newcost += transfer_cost;
           }
 
+          const TransitRoute* transit_route = tile->GetTransitRoute(
+              departure->routeid());
+
+          //operator diff
+          if (transit_route && transit_route->op_by_onestop_id_offset()) {
+            std::string id = tile->GetName(transit_route->op_by_onestop_id_offset());
+
+            if (onestop_id.empty()) //first pass.
+              onestop_id = id;
+
+            if (onestop_id != id) {
+              Cost tc = transfer_cost;
+              tc.cost *= 1.5f;
+              newcost += tc;
+              onestop_id = id;
+            }
+          }
           // Change mode and costing to transit. Add edge cost.
           mode_ = TravelMode::kPublicTransit;
           newcost += tc->EdgeCost(directededge, departure, localtime);


### PR DESCRIPTION
This with thor updates fixes switching operators, taking buses when not needed, and take a more desired bus route.


<pre><code>
Avoid path example://

<    Depart: 8:05 AM from 23rd Street.
<    VERBAL_DEPART: Depart at 8:05 AM from 23rd Street.
< 4: Take the PATH toward Journal Square. (1 stop) | 0.4 mi
<    VERBAL_PRE: Take the PATH toward Journal Square.
<    VERBAL_POST: Travel 1 stop.
<    Arrive: 8:06 AM at 14th Street.
<    VERBAL_ARRIVE: Arrive at 8:06 AM at 14th Street.
< 5: Transfer at the 6 Av station. | 0.0 mi
<    VERBAL_PRE: Transfer at the 6 Av station.
<    VERBAL_POST: Continue for 20 feet.
<    Depart: 8:06 AM from 6 Av.
<    VERBAL_DEPART: Depart at 8:06 AM from 6 Av.
< 6: Take the L toward CANARSIE - ROCKAWAY PKWY. (9 stops) | 4.2 mi
<    VERBAL_PRE: Take the L toward CANARSIE - ROCKAWAY PKWY.
<    VERBAL_POST: Travel 9 stops.
<    Arrive: 8:20 AM at Morgan Av.
<    VERBAL_ARRIVE: Arrive at 8:20 AM at Morgan Av.
> 9: Enter the Union Sq - 14 St station. | 0.0 mi
>    VERBAL_PRE: Enter the Union Sq - 14 St station.
>    VERBAL_POST: Continue for 30 feet.
>    Depart: 8:11 AM from Union Sq - 14 St.
>    VERBAL_DEPART: Depart at 8:11 AM from Union Sq - 14 St.
> 10: Take the L toward MYRTLE - WYCKOFF AVS. (8 stops) | 3.8 mi
>    VERBAL_PRE: Take the L toward MYRTLE - WYCKOFF AVS.
>    VERBAL_POST: Travel 8 stops.
>    Arrive: 8:23 AM at Morgan Av.

No need to take a bus example://

< 5: Head north on Church Street. | 0.0 mi
<    VERBAL_PRE: Head north on Church Street.
<    VERBAL_POST: Continue for 40 feet.
> 5: Head south on Church Street. | 0.3 mi
>    VERBAL_PRE: Head south on Church Street.
>    VERBAL_POST: Continue for 3 tenths of a mile.
27,33c27,29
<    Depart: 5:44 PM from Church St & Duboce Ave.
<    VERBAL_DEPART: Depart at 5:44 PM from Church St & Duboce Ave.
< 6: Take the 22 toward Potrero Hill. (2 stops) | 0.3 mi
<    VERBAL_PRE: Take the 22 toward Potrero Hill.
<    VERBAL_POST: Travel 2 stops.
<    Arrive: 5:48 PM at Church St & 16th St.
<    VERBAL_ARRIVE: Arrive at 5:48 PM at Church St & 16th St.
> 6: Enter the Church St & 16th St station. | 0.0 mi
>    VERBAL_PRE: Enter the Church St & 16th St station.
>    VERBAL_POST: Continue for 20 feet.
37,38c33,34
< 7: Transfer to take the J toward Balboa Park Station. (9 stops) | 1.5 mi
<    VERBAL_PRE: Transfer to take the J toward Balboa Park Station.
> 7: Take the J toward Balboa Park Station. (9 stops) | 1.5 mi
>    VERBAL_PRE: Take the J toward Balboa Park Station.

Better bus result.  22 to 522 is better.

<    Depart: 8:23 AM from EL CAMINO & CALDERON.
<    VERBAL_DEPART: Depart at 8:23 AM from EL CAMINO & CALDERON.
< 5: Take the 22. (2 stops) | 0.5 mi
<    VERBAL_PRE: Take the 22.
<    VERBAL_POST: Travel 2 stops.
<    Arrive: 8:27 AM at EL CAMINO & CASTRO.
<    VERBAL_ARRIVE: Arrive at 8:27 AM at EL CAMINO & CASTRO.
>    Depart: 8:27 AM from MOUNTAIN VIEW CALTRAIN STATION.
>    VERBAL_DEPART: Depart at 8:27 AM from MOUNTAIN VIEW CALTRAIN STATION.
> 7: Take the 52. (4 stops) | 0.7 mi
>    VERBAL_PRE: Take the 52.
>    VERBAL_POST: Travel 4 stops.
>    Arrive: 8:33 AM at EL CAMINO & CASTRO.
>    VERBAL_ARRIVE: Arrive at 8:33 AM at EL CAMINO & CASTRO.
32c42
< 6: Transfer to take the 522. (4 stops) | 6.0 mi
> 8: Transfer to take the 522. (4 stops) | 6.0 mi

</code></pre>