### PR TITLE
Update EdgeLabels to include an operator index.

### DIFF
--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -230,7 +230,7 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
       // if allowed by costing - assume if you get a transit edge you
       // walked to the transit stop
       tripid = 0;
-      operator_id = 0;
+      operator_id = pred.transit_operator();
       if (directededge->IsTransitLine()) {
         const TransitDeparture* departure = tile->GetNextDeparture(
                     directededge->lineid(), localtime, day, dow, date_before_tile);

--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -378,7 +378,7 @@ void PathAlgorithm::SetOrigin(GraphReader& graphreader,
     adjacencylist_->Add(edgelabels_.size(), sortcost);
     EdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
             sortcost, dist, directededge->restrictions(),
-            directededge->opp_local_idx(), mode_, d, 0, 0, 0, false);
+            directededge->opp_local_idx(), mode_, d, 0, 0, 0, 0, false);
     edge_label.set_origin();
 
     // Set the origin flag

--- a/src/thor/timedistancematrix.cc
+++ b/src/thor/timedistancematrix.cc
@@ -161,7 +161,7 @@ std::vector<TimeDistance> TimeDistanceMatrix::OneToMany(
       edgelabels_.emplace_back(predindex, edgeid, directededge,
                     newcost, newcost.cost, 0.0f, directededge->restrictions(),
                     directededge->opp_local_idx(), mode_, distance,
-                    0, 0, 0, false);
+                    0, 0, 0, 0, false);
     }
   }
   return {};      // Should never get here
@@ -308,7 +308,7 @@ std::vector<TimeDistance> TimeDistanceMatrix::ManyToOne(
       edgelabels_.emplace_back(predindex, edgeid, directededge,
                     newcost, newcost.cost, 0.0f, directededge->restrictions(),
                     directededge->opp_local_idx(), mode_, distance,
-                    0, 0, 0, false);
+                    0, 0, 0, 0, false);
     }
   }
   return {};      // Should never get here
@@ -368,7 +368,7 @@ void TimeDistanceMatrix::SetOriginOneToMany(GraphReader& graphreader,
     adjacencylist_->Add(edgelabels_.size(), cost.cost);
     EdgeLabel edge_label(kInvalidLabel, edgeid, directededge, cost,
             cost.cost, 0.0f, directededge->restrictions(),
-            directededge->opp_local_idx(), mode_, d, 0, 0, 0, false);
+            directededge->opp_local_idx(), mode_, d, 0, 0, 0, 0, false);
     edge_label.set_origin();
     edgelabels_.push_back(std::move(edge_label));
   }
@@ -412,7 +412,7 @@ void TimeDistanceMatrix::SetOriginManyToOne(GraphReader& graphreader,
     adjacencylist_->Add(edgelabels_.size(), cost.cost);
     EdgeLabel edge_label(kInvalidLabel, opp_edge_id, opp_dir_edge, cost,
             cost.cost, 0.0f, 0, opp_dir_edge->opp_local_idx(), mode_, d,
-            0, 0, 0, false);
+            0, 0, 0, 0, false);
     edge_label.set_origin();
     edgelabels_.push_back(std::move(edge_label));
   }


### PR DESCRIPTION
This is an index into a map of operator names. This allows us to compare an operator to the predecessor operator and to add a penalty if not the same.