### PR TITLE
Use correct cost in Adjacency List 

### DIFF
--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -7,6 +7,33 @@
 using namespace valhalla::baldr;
 using namespace valhalla::sif;
 
+namespace {
+
+// Method to get an operator Id from a map of operator strings vs. Id.
+uint32_t GetOperatorId(const GraphTile* tile, uint32_t routeid,
+            std::unordered_map<std::string, uint32_t>& operators) {
+  const TransitRoute* transit_route = tile->GetTransitRoute(routeid);
+
+  // Test if the transit operator changed
+  if (transit_route && transit_route->op_by_onestop_id_offset()) {
+    // Get the operator name and look up in the operators map
+    std::string operator_name =
+        tile->GetName(transit_route->op_by_onestop_id_offset());
+    auto operator_itr = operators.find(operator_name);
+    if (operator_itr == operators.end()) {
+      // Operator not found - add to the map
+      uint32_t id = operators.size() + 1;
+      operators[operator_name] = id;
+      return id;
+    } else {
+      return operator_itr->second;
+    }
+  }
+  return 0;
+}
+
+}
+
 namespace valhalla {
 namespace thor {
 
@@ -93,7 +120,7 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
   }
 
   // Find shortest path
-  uint32_t blockid, tripid, prior_stop, operator_id;
+  uint32_t blockid, tripid, operator_id;
   uint32_t nc = 0;       // Count of iterations with no convergence
                          // towards destination
   std::unordered_map<std::string, uint32_t> operators;
@@ -152,7 +179,10 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
       continue;
     }
 
-    // Set a default transfer at a stop (if not same trip Id and block Id)
+    // Set local time. TODO: adjust for time zone.
+    uint32_t localtime = start_time + pred.cost().secs;
+
+    // Set a default transfer penalty at a stop (if not same trip Id and block Id)
     Cost transfer_cost = tc->DefaultTransferCost();
 
     // Get any transfer times and penalties if this is a transit stop (and
@@ -161,21 +191,22 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
     bool has_transit = pred.has_transit();
     uint32_t prior_stop = pred.prior_stopid();
     if (nodeinfo->type() == NodeType::kMultiUseTransitStop) {
+      // Get the transfer penalty when changing stations
       if (mode_ == TravelMode::kPedestrian && prior_stop != 0 && has_transit) {
         transfer_cost = tc->TransferCost(tile->GetTransfer(prior_stop,
                                       nodeinfo->stop_index()));
       }
 
-      // Update prior stop.
-      // TODO - parent/child stop info?
+      // Add transfer time to the local time when first entering any
+      // stop as a pedestrian. This is a small added cost on top of
+      // any costs along paths and roads
+      if (mode_ == TravelMode::kPedestrian) {
+        localtime += transfer_cost.secs;
+      }
+
+      // Update prior stop. TODO - parent/child stop info?
       prior_stop = nodeinfo->stop_index();
     }
-
-    // Set local time. TODO: adjust for time zone. Add true transfer time.
-    // Update transfer cost so all that remains is the cost penalty
-    uint32_t localtime = start_time + pred.cost().secs + transfer_cost.secs;
-    transfer_cost.cost -= transfer_cost.secs;
-    transfer_cost.secs = 0.0f;
 
     // Allow mode changes at special nodes
     //      bike share (pedestrian <--> bicycle)
@@ -229,7 +260,8 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
       // If this is a transit edge - get the next departure. Do not check
       // if allowed by costing - assume if you get a transit edge you
       // walked to the transit stop
-      tripid = 0;
+      tripid  = 0;
+      blockid = 0;
       operator_id = pred.transit_operator();
       if (directededge->IsTransitLine()) {
         const TransitDeparture* departure = tile->GetNextDeparture(
@@ -243,36 +275,38 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
           blockid = departure->blockid();
           has_transit = true;
 
-          // Add transfer cost. There is no cost if continuing along the
-          // same trip Id or (valid) block Id.
-          if (tripid != pred.tripid() ||
-              (blockid != 0 && blockid != pred.blockid())) {
-            newcost += transfer_cost;
-
-            const TransitRoute* transit_route = tile->GetTransitRoute(
-                departure->routeid());
-
-            // Test if the transit operator changed
-            if (transit_route && transit_route->op_by_onestop_id_offset()) {
-              std::string operator_name =
-                    tile->GetName(transit_route->op_by_onestop_id_offset());
-
-              // Look up in the operators map
-              auto operator_itr = operators.find(operator_name);
-              if (operator_itr == operators.end()) {
-                // Operator not found - add to the map
-                operator_id = operators.size() + 1;
-                operators[operator_name] = operator_id;
-              } else {
-                // Get the operator index and compare to the predecessor. Add
-                // penalty if not the same index
-                operator_id = operator_itr->second;
-                if (pred.transit_operator() > 0 &&
-                    pred.transit_operator() != operator_id) {
-                  // TODO - create a configurable operator change penalty
-                  newcost.cost += transfer_cost.cost * 1.5f;
-                }
+          // There is no cost to remain on the same trip or valid blockId
+          if ( tripid == pred.tripid() ||
+              (blockid != 0 && blockid == pred.blockid())) {
+            // This departure is valid without any added cost. Operator Id is
+            // same as the predecessor
+            operator_id = pred.transit_operator();
+          } else {
+            if (pred.tripid() > 0) {
+              // tripId > 0 means the prior edge was a transit edge and this
+              // is an "in-station" transfer. Add a small transfer time and
+              // call GetNextDeparture again if we cannot make the current
+              // departure. Add transfer penalty.
+              // TODO - is there a better way?
+              if (localtime + 30 > departure->departure_time()) {
+                  departure = tile->GetNextDeparture(directededge->lineid(),
+                                localtime + 30, day, dow, date_before_tile);
+                if (!departure)
+                  continue;
               }
+              newcost.cost += transfer_cost.cost;
+            }
+
+            // Get the operator Id
+            operator_id = GetOperatorId(tile, departure->routeid(), operators);
+
+            // Not following along same trip - check if we need to add an
+            // operator change penalty. TODO - make this a method?
+            if (pred.transit_operator() > 0 &&
+                pred.transit_operator() != operator_id) {
+              // TODO - create a configurable operator change penalty
+              newcost.secs += 60.0f;
+              newcost.cost += transfer_cost.cost * 20.0f;
             }
           }
 
@@ -380,7 +414,7 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
       edgelabels_.emplace_back(predindex, edgeid, directededge,
                     newcost, sortcost, dist, directededge->restrictions(),
                     directededge->opp_local_idx(), mode_,  walking_distance_,
-                    tripid, prior_stop,  blockid, operator_id, has_transit);
+                    tripid, prior_stop, blockid, operator_id, has_transit);
     }
   }
   return {};      // Should never get here

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -459,6 +459,9 @@ TripPath TripPathBuilder::Build(GraphReader& graphreader,
         const TransitDeparture* transit_departure = graphtile
             ->GetTransitDeparture(graphtile->directededge(edge.id())->lineid(),
                                   trip_id);
+
+        std::cout << std::to_string(trip_id) << std::endl;
+
         assumed_schedule = false;
         uint32_t date, day = 0;
         if (origin.date_time_) {
@@ -879,7 +882,7 @@ TripPath_Edge* TripPathBuilder::AddTripEdge(const uint32_t idx,
     // TODO: Need to set based on GTFS values
     if (directededge->use() == Use::kRail)
       trip_edge->set_transit_type(
-          TripPath_TransitType::TripPath_TransitType_kMetro);
+          TripPath_TransitType::TripPath_TransitType_kRail);
 
     if (directededge->use() == Use::kBus)
       trip_edge->set_transit_type(


### PR DESCRIPTION
Add a GetOperatorId method. Update in-station vs. stop-to-stop transfer logic and if in-station make sure a transfer time is added and the departure is still valid (not in the past after adding the transfer time). Wrong value was being added to Adjacency List! Other changes include the way transfer cost is set and an operator change penalty is added.

	
