### PR TITLE
Update termination criteria and properly handle not_thru edges.

### DIFF
--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -165,9 +165,11 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
           if (threshold == 0) {
             threshold = GetThreshold(mode_, edgelabels_.size() + edgelabels_reverse_.size());
           }
-          uint32_t predindex = edgelabels_reverse_[oppedgestatus.status.index].predecessor();
-          float c = pred.cost().cost + edgelabels_reverse_[predindex].cost().cost +
-                edgelabels_reverse_[predindex].transition_cost();
+          uint32_t predidx = edgelabels_reverse_[oppedgestatus.status.index].predecessor();
+          float oppcost = (predidx == kInvalidLabel) ?
+              0 : edgelabels_reverse_[predidx].cost().cost;
+          float c = pred.cost().cost + oppcost +
+              edgelabels_reverse_[oppedgestatus.status.index].transition_cost();
           if (c < best_connection_.cost) {
             best_connection_ = { pred.edgeid(), oppedge, c };
 LOG_TRACE("New best connection: forward: c = " + std::to_string(c) +
@@ -246,9 +248,8 @@ LOG_TRACE("");
 
         // Get cost
         Cost newcost = pred.cost() +
-                      costing->EdgeCost(directededge, nodeinfo->density());
-        Cost tc = costing->TransitionCost(directededge, nodeinfo, pred);
-        newcost.cost += tc.cost;
+                      costing->EdgeCost(directededge, nodeinfo->density()) +
+                      costing->TransitionCost(directededge, nodeinfo, pred);
 
         // Check if edge is temporarily labeled and this path has less cost. If
         // less cost the predecessor is updated and the sort cost is decremented
@@ -306,9 +307,11 @@ LOG_TRACE("");
           if (threshold == 0) {
             threshold = GetThreshold(mode_, edgelabels_.size() + edgelabels_reverse_.size());
           }
-          uint32_t predindex = edgelabels_[oppedgestatus.status.index].predecessor();
-          float c = pred2.cost().cost + edgelabels_[predindex].cost().cost +
-                edgelabels_[predindex].transition_cost();
+          uint32_t predidx = edgelabels_[oppedgestatus.status.index].predecessor();
+          float oppcost = (predidx == kInvalidLabel) ?
+                0 : edgelabels_[predidx].cost().cost;
+          float c = pred2.cost().cost + oppcost +
+                edgelabels_[oppedgestatus.status.index].transition_cost();
           if (c < best_connection_.cost) {
             best_connection_ = { oppedge, pred2.edgeid(), c };
 

--- a/valhalla/thor/bidirectional_astar.h
+++ b/valhalla/thor/bidirectional_astar.h
@@ -82,15 +82,6 @@ class BidirectionalAStar : public PathAlgorithm {
             const std::shared_ptr<sif::DynamicCost>& costing);
 
   /**
-   * Test if the edge and its opposing edge is the best connection.
-   * @param  edge     Graph ID of the directed edge.
-   * @param  oppedge  GraphId of the opposing directed edge.
-   * @return Returns true if this edge pair is the best connection.
-   */
-  bool IsBestConnection(const baldr::GraphId& edge,
-                       const baldr::GraphId& oppedge) const;
-
-  /**
    * Add edges at the origin to the forward adjacency list.
    * @param  graphreader  Graph tile reader.
    * @param  origin       Location information of the destination


### PR DESCRIPTION
Extend the searches after an initial connection has been found to allow for connections along long edges. Probably should be based on max edge cost but that reduces performance significantly so use a threshold based on number of iterations. Also - add not_thru edges to EdgeLabels and mark them, but do not add to adjacency list (effectively prunes search but allows connections on them for case where origin and destination connect at a shared node with both entering not_thru edges).