### PR TITLE
Stupid fingers...ignore branch name.

### DIFF
--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -18,7 +18,7 @@ wait
 for dep in midgard baldr sif odin; do
 	pushd deps/$dep
 	./autogen.sh
-	./configure CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
+	./configure CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS"
 	make -j$(nproc)
 	sudo make install
 	popd

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,6 @@ set -e
 
 export LD_LIBRARY_PATH=.:`cat /etc/ld.so.conf.d/* | grep -v -E "#" | tr "\\n" ":" | sed -e "s/:$//g"`
 ./autogen.sh
-./configure --enable-coverage CPPFLAGS=-DBOOST_SPIRIT_THREADSAFE
+./configure --enable-coverage CPPFLAGS="-DBOOST_SPIRIT_THREADSAFE -DBOOST_NO_CXX11_SCOPED_ENUMS"
 make test -j$(nproc)
 sudo make install


### PR DESCRIPTION
We must get the date from level 3 transit tiles and not level 2.  The level 3 date is set when the fetcher grabbed the transit data and created the schedules.  
Moved prevent going from one transit connection directly to another at a transit stop logic from sif to here.