### PR TITLE
Update hierarchy limits

### DIFF
--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -612,6 +612,12 @@ void CostMatrix::SetSources(baldr::GraphReader& graphreader,
                                         costing->UnitSize());
     source_hierarchy_limits_[index] = costing->GetHierarchyLimits();
 
+    // Since there is no distance to destination lets increase the
+    // number of upward transitions so we expand the local and arterial
+    // longer since most cost matrices are short routes
+    source_hierarchy_limits_[index][1].max_up_transitions = 2000;
+    source_hierarchy_limits_[index][2].max_up_transitions = 100;
+
     // Iterate through edges and add to adjacency list
     for (const auto& edge : (origin.edges())) {
       // If origin is at a node - skip any inbound edge (dist = 1)
@@ -674,6 +680,12 @@ void CostMatrix::SetTargets(baldr::GraphReader& graphreader,
     target_adjacency_[index] = new AdjacencyList(0, cost_threshold_,
                                           costing->UnitSize());
     target_hierarchy_limits_[index] = costing->GetHierarchyLimits();
+
+    // Since there is no distance to destination lets increase the
+    // number of upward transitions so we expand the local and arterial
+    // longer since most cost matrices are short routes
+    target_hierarchy_limits_[index][1].max_up_transitions = 2000;
+    target_hierarchy_limits_[index][2].max_up_transitions = 100;
 
     // Iterate through edges and add to adjacency list
     for (const auto& edge : (dest.edges())) {

--- a/valhalla/thor/costmatrix.h
+++ b/valhalla/thor/costmatrix.h
@@ -64,7 +64,13 @@ struct BestCandidate {
   }
 };
 
-// Class to compute cost (cost + time + distance) matrices among locations.
+/**
+ * Class to compute cost (cost + time + distance) matrices among locations.
+ * This uses a bidirectional search with highway hierarchies. This is a
+ * method described by Sebastian Knopp, "Efficient Computation of Many-to-Many
+ * Shortest Paths".
+ * https://i11www.iti.uni-karlsruhe.de/_media/teaching/theses/files/da-sknopp-06.pdf
+ */
 class CostMatrix {
  public:
   /**


### PR DESCRIPTION
Just update in CostMatrix until better thresholds can be set for bidirectional A*. Add comments and reference to Knopp paper.