### PR TITLE
Do not reserve EdgeLabels in PathAlgorithm

### DIFF
--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -22,8 +22,7 @@ PathAlgorithm::PathAlgorithm()
       allow_transitions_(false),
       adjacencylist_(nullptr),
       edgestatus_(nullptr),
-      tile_creation_date_(0),
-      walking_distance_(0) {
+      tile_creation_date_(0) {
 }
 
 // Destructor

--- a/src/thor/pathalgorithm.cc
+++ b/src/thor/pathalgorithm.cc
@@ -22,8 +22,8 @@ PathAlgorithm::PathAlgorithm()
       allow_transitions_(false),
       adjacencylist_(nullptr),
       edgestatus_(nullptr),
-      tile_creation_date_(0) {
-  edgelabels_.reserve(kInitialEdgeLabelCount);
+      tile_creation_date_(0),
+      walking_distance_(0) {
 }
 
 // Destructor
@@ -62,6 +62,10 @@ void PathAlgorithm::Init(const PointLL& origll, const PointLL& destll,
   float range = kBucketCount * bucketsize;
   adjacencylist_.reset(new AdjacencyList(mincost, range, bucketsize));
   edgestatus_.reset(new EdgeStatus());
+
+  // Reserve size for edge labels - do this here rather than in constructor so
+  // to limit how much extra memory is used for persistent objects
+  edgelabels_.reserve(kInitialEdgeLabelCount);
 
   // Get hierarchy limits from the costing. Get a copy since we increment
   // transition counts (i.e., this is not a const reference).


### PR DESCRIPTION
This constructor is used in TimeDistanceMatrix. Both PathAlgorithm and TimeDistanceMatrix have been largely replaced by BidirectionalAstar and CostMatrix. No sense allocating this memory (which exists in some persistent objects in thor service.