### PR TITLE
Check if a transit directed edge is allowed by the transit costing method

### DIFF
--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -279,6 +279,12 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
       tripid  = 0;
       blockid = 0;
       if (directededge->IsTransitLine()) {
+        // Check if transit costing allows this edge
+        if (!tc->Allowed(directededge, pred, tile, edgeid)) {
+          continue;
+        }
+
+        // Look up the next departure along this edge
         const TransitDeparture* departure = tile->GetNextDeparture(
                     directededge->lineid(), localtime, day, dow, date_before_tile);
         if (departure) {


### PR DESCRIPTION
If use_bus or use_rail is false this will now avoid any lines of that type.