### PR TITLE
nullptr_t → std::nullptr_t

### DIFF
--- a/src/thor/matrix.cc
+++ b/src/thor/matrix.cc
@@ -61,8 +61,8 @@ namespace {
         row->emplace_back(json::map({
           {"from_index", static_cast<uint64_t>(origin)},
           {"to_index", static_cast<uint64_t>(destination + (i - start))},
-          {"time", static_cast<nullptr_t>(nullptr)},
-          {"distance", static_cast<nullptr_t>(nullptr)}
+          {"time", static_cast<std::nullptr_t>(nullptr)},
+          {"distance", static_cast<std::nullptr_t>(nullptr)}
         }));
       }
     }


### PR DESCRIPTION
nullptr_t is part of the std namespace. This patch fixes a build error on OpenBSD.