### PR TITLE
Added GetOffsetForHeading method that will adjust heading offset based on road class and 'use'

### DIFF
--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -20,9 +20,6 @@ using namespace valhalla::odin;
 
 namespace {
 
-// Meters offset from start/end of shape for finding heading
-constexpr float kMetersOffsetForHeading = 30.0f;
-
 template<class iter>
 void AddPartialShape(std::vector<PointLL>& shape, iter start, iter end,
                      float partial_length, bool back_insert,
@@ -840,12 +837,14 @@ TripPath_Edge* TripPathBuilder::AddTripEdge(const uint32_t idx,
 
     trip_edge->set_begin_heading(
         std::round(
-            PointLL::HeadingAlongPolyline(edgeinfo->shape(),
-                                          kMetersOffsetForHeading)));
+            PointLL::HeadingAlongPolyline(
+                edgeinfo->shape(),
+                GetOffsetForHeading(directededge->classification()))));
     trip_edge->set_end_heading(
         std::round(
-            PointLL::HeadingAtEndOfPolyline(edgeinfo->shape(),
-                                            kMetersOffsetForHeading)));
+            PointLL::HeadingAtEndOfPolyline(
+                edgeinfo->shape(),
+                GetOffsetForHeading(directededge->classification()))));
   } else {
     // Reverse driveability and heading
     if ((directededge->forwardaccess() & kAccess)
@@ -867,16 +866,19 @@ TripPath_Edge* TripPathBuilder::AddTripEdge(const uint32_t idx,
     trip_edge->set_begin_heading(
         std::round(
             fmod(
-                (PointLL::HeadingAtEndOfPolyline(edgeinfo->shape(),
-                                                 kMetersOffsetForHeading)
+                (PointLL::HeadingAtEndOfPolyline(
+                    edgeinfo->shape(),
+                    GetOffsetForHeading(directededge->classification()))
                     + 180.0f),
                 360)));
 
     trip_edge->set_end_heading(
         std::round(
             fmod(
-                (PointLL::HeadingAlongPolyline(edgeinfo->shape(),
-                                               kMetersOffsetForHeading) + 180.0f),
+                (PointLL::HeadingAlongPolyline(
+                    edgeinfo->shape(),
+                    GetOffsetForHeading(directededge->classification()))
+                    + 180.0f),
                 360)));
   }
 

--- a/src/thor/trippathbuilder.cc
+++ b/src/thor/trippathbuilder.cc
@@ -839,12 +839,14 @@ TripPath_Edge* TripPathBuilder::AddTripEdge(const uint32_t idx,
         std::round(
             PointLL::HeadingAlongPolyline(
                 edgeinfo->shape(),
-                GetOffsetForHeading(directededge->classification()))));
+                GetOffsetForHeading(directededge->classification(),
+                                    directededge->use()))));
     trip_edge->set_end_heading(
         std::round(
             PointLL::HeadingAtEndOfPolyline(
                 edgeinfo->shape(),
-                GetOffsetForHeading(directededge->classification()))));
+                GetOffsetForHeading(directededge->classification(),
+                                    directededge->use()))));
   } else {
     // Reverse driveability and heading
     if ((directededge->forwardaccess() & kAccess)
@@ -868,8 +870,8 @@ TripPath_Edge* TripPathBuilder::AddTripEdge(const uint32_t idx,
             fmod(
                 (PointLL::HeadingAtEndOfPolyline(
                     edgeinfo->shape(),
-                    GetOffsetForHeading(directededge->classification()))
-                    + 180.0f),
+                    GetOffsetForHeading(directededge->classification(),
+                                        directededge->use())) + 180.0f),
                 360)));
 
     trip_edge->set_end_heading(
@@ -877,8 +879,8 @@ TripPath_Edge* TripPathBuilder::AddTripEdge(const uint32_t idx,
             fmod(
                 (PointLL::HeadingAlongPolyline(
                     edgeinfo->shape(),
-                    GetOffsetForHeading(directededge->classification()))
-                    + 180.0f),
+                    GetOffsetForHeading(directededge->classification(),
+                                        directededge->use())) + 180.0f),
                 360)));
   }
 


### PR DESCRIPTION
depends on valhalla/baldr#273
fixes valhalla/odin#352
fixes valhalla/odin#296

``` Diff
< BEFORE
< 1: Drive south on Penwethers Lane. | 0.1 mi
> AFTER
> 1: Drive south on Penwethers Lane. | 0.1 mi
> 2: Turn left to stay on Penwethers Lane. | 0.0 mi
```
