### PR TITLE
Use GetThreshold in CostMatrix

### DIFF
--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -363,6 +363,12 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
   // Set the origin locations.
   SetOriginLocations(graphreader, origin_locations, costing);
 
+  // For now the date_time must be set on the origin.
+  if (!origin_locations.front().date_time_) {
+    LOG_ERROR("No date time set on the origin location");
+    return isotile_;
+  }
+
   // Update start time
   uint32_t start_time, localtime, date, dow, day = 0;
   bool date_before_tile = false;

--- a/valhalla/thor/costmatrix.h
+++ b/valhalla/thor/costmatrix.h
@@ -14,7 +14,6 @@
 #include <valhalla/sif/edgelabel.h>
 #include <valhalla/thor/adjacencylist.h>
 #include <valhalla/thor/edgestatus.h>
-#include <valhalla/thor/timedistancematrix.h>
 
 namespace valhalla {
 namespace thor {
@@ -22,6 +21,24 @@ namespace thor {
 // Use a 4 hour cost threshold. This is in addition to the distance
 // thresholds for quick rejection
 constexpr float kCostThresholdDefault = 14400.0f;   // 4 hours
+constexpr float kMaxCost = 99999999.9999f;
+
+
+// Time and Distance structure
+struct TimeDistance {
+  uint32_t time;  // Time in seconds
+  uint32_t dist;  // Distance in meters
+
+  TimeDistance()
+      : time(0),
+        dist(0) {
+  }
+
+  TimeDistance(const uint32_t secs, const uint32_t meters)
+      : time(secs),
+        dist(meters) {
+  }
+};
 
 /**
  * Status of a location. Tracks remaining locations to be found


### PR DESCRIPTION
Try to match the behavior of bidirectional A* (rather than a fixed number of iterations after the first connection has been found). 
Make sure date time is set on origin location for multi-modal isochrones (prevents crash).