### PR TITLE
Enable distancematrix for one to many

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,6 +53,7 @@ nobase_include_HEADERS = \
 	valhalla/thor/trippathbuilder.h \
 	valhalla/thor/service.h \
 	valhalla/thor/trafficalgorithm.h
+	valhalla/thor/timedistancematrix.h
 libvalhalla_thor_la_SOURCES = \
 	src/thor/astar.cc \
 	src/thor/astarheuristic.cc \
@@ -69,7 +70,8 @@ libvalhalla_thor_la_SOURCES = \
 	src/thor/route_action.cc \
 	src/thor/trippathbuilder.cc \
 	src/thor/service.cc \
-	src/thor/trafficalgorithm.cc
+	src/thor/trafficalgorithm.cc \
+        src/thor/timedistancematrix.cc
 
 libvalhalla_thor_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_thor_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) @PROTOC_LIBS@

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,7 @@ libvalhalla_thor_la_SOURCES = \
 	src/thor/trippathbuilder.cc \
 	src/thor/service.cc \
 	src/thor/trafficalgorithm.cc \
-        src/thor/timedistancematrix.cc
+	src/thor/timedistancematrix.cc
 
 libvalhalla_thor_la_CPPFLAGS = $(DEPS_CFLAGS) $(VALHALLA_DEPS_CFLAGS) @BOOST_CPPFLAGS@
 libvalhalla_thor_la_LIBADD = $(DEPS_LIBS) $(VALHALLA_DEPS_LIBS) $(BOOST_PROGRAM_OPTIONS_LIB) $(BOOST_FILESYSTEM_LIB) $(BOOST_SYSTEM_LIB) $(BOOST_THREAD_LIB) @PROTOC_LIBS@

--- a/src/thor/matrix_action.cc
+++ b/src/thor/matrix_action.cc
@@ -11,6 +11,7 @@ using namespace prime_server;
 
 #include "thor/service.h"
 #include "thor/costmatrix.h"
+#include "thor/timedistancematrix.h"
 
 using namespace valhalla;
 using namespace valhalla::midgard;
@@ -124,10 +125,17 @@ namespace valhalla {
         distance_scale = kMilePerMeter;
 
       json::MapPtr json;
-      //do the real work
-      thor::CostMatrix costmatrix;
-      json = serialize(matrix_type, request.get_optional<std::string>("id"), correlated_s, correlated_t,
-        costmatrix.SourceToTarget(correlated_s, correlated_t, reader, mode_costing, mode), units, distance_scale);
+      if (action == thor_worker_t::ONE_TO_MANY ){
+          thor::TimeDistanceMatrix timedistance_matrix;
+          json = serialize(matrix_type, request.get_optional<std::string>("id"), correlated_s, correlated_t,
+        		  timedistance_matrix.OneToMany(0,
+        				  correlated_t, reader, mode_costing, mode), units, distance_scale);
+      }else {
+          //do the real work
+          thor::CostMatrix costmatrix;
+          json = serialize(matrix_type, request.get_optional<std::string>("id"), correlated_s, correlated_t,
+            costmatrix.SourceToTarget(correlated_s, correlated_t, reader, mode_costing, mode), units, distance_scale);
+      }
 
       //jsonp callback if need be
       std::ostringstream stream;

--- a/src/thor/matrix_action.cc
+++ b/src/thor/matrix_action.cc
@@ -126,15 +126,14 @@ namespace valhalla {
 
       json::MapPtr json;
       if (action == thor_worker_t::ONE_TO_MANY ){
-          thor::TimeDistanceMatrix timedistance_matrix;
-          json = serialize(matrix_type, request.get_optional<std::string>("id"), correlated_s, correlated_t,
-        		  timedistance_matrix.OneToMany(0,
-        				  correlated_t, reader, mode_costing, mode), units, distance_scale);
-      }else {
-          //do the real work
-          thor::CostMatrix costmatrix;
-          json = serialize(matrix_type, request.get_optional<std::string>("id"), correlated_s, correlated_t,
-            costmatrix.SourceToTarget(correlated_s, correlated_t, reader, mode_costing, mode), units, distance_scale);
+        thor::TimeDistanceMatrix timedistance_matrix;
+        json = serialize(matrix_type, request.get_optional<std::string>("id"), correlated_s, correlated_t,
+          timedistance_matrix.OneToMany(0, correlated_t, reader, mode_costing, mode), units, distance_scale);
+      } else {
+        //do the real work
+        thor::CostMatrix costmatrix;
+        json = serialize(matrix_type, request.get_optional<std::string>("id"), correlated_s, correlated_t,
+          costmatrix.SourceToTarget(correlated_s, correlated_t, reader, mode_costing, mode), units, distance_scale);
       }
 
       //jsonp callback if need be

--- a/valhalla/thor/timedistancematrix.h
+++ b/valhalla/thor/timedistancematrix.h
@@ -21,37 +21,9 @@
 namespace valhalla {
 namespace thor {
 
-//constexpr float kMaxCost = 99999999.9999f;
 constexpr float kDefaultCostThreshold = 7200.0f;  // 2 hours
 
-/* 
-// Time and Distance structure
-struct TimeDistance {
-  uint32_t time;  // Time in seconds
-  uint32_t dist;  // Distance in meters
 
-  TimeDistance()
-      : time(0),
-        dist(0) {
-  }
-
-  TimeDistance(const uint32_t secs, const uint32_t meters)
-      : time(secs),
-        dist(meters) {
-  }
-};*/
-
-// Structure to hold time distance results from a thread (for many to many
-// time distance matrix)
-struct TimeDistanceResults {
-  uint32_t origin_index;  // Origin index of the one to many result
-  std::vector<TimeDistance> time_distance;
-
-  // Sorting method to sort by origin_index
-  bool operator < (const TimeDistanceResults& other) const {
-    return origin_index < other.origin_index;
-  }
-};
 
 // Structure to hold information about each destination.
 struct Destination {
@@ -76,7 +48,7 @@ struct Destination {
 };
 
 // Class to compute time + distance matrices among locations.
-class TimeDistanceMatrix : public PathAlgorithm {
+class TimeDistanceMatrix {
  public:
   /**
    * Constructor with cost threshold.
@@ -135,13 +107,8 @@ class TimeDistanceMatrix : public PathAlgorithm {
    * Clear the temporary information generated during time+distance
    * matrix construction.
    */
-  virtual void Clear();
+  void Clear();
 
-  virtual std::vector<PathInfo> GetBestPath(baldr::PathLocation& origin,
-          baldr::PathLocation& dest, baldr::GraphReader& graphreader,
-          const std::shared_ptr<sif::DynamicCost>* mode_costing,
-          const sif::TravelMode mode) {
-	  return {}; };
  protected:
   // Number of destinations that have been found and settled (least cost path
   // computed).


### PR DESCRIPTION
Hello Valhalla! Greetings from Navitia! 

As we discussed in this issue: https://github.com/valhalla/thor/issues/408, we have been working on the api `one_to_many` for a couple of days. 

## **Why we are re-working on this**
(you're surely aware of all problems of your own baby :laughing: , this is only for the sake of traceability): 

- `one_to_many`/`many_to_one`/`many_to_many` api's `max_locations` is limited to 50 because of the huge demand  in RAM
- Response time is not satisfying for our use case 

## **What we have done in this PR**

As suggested in the  https://github.com/valhalla/thor/issues/408, we try enabling the `timedistancematrix.cc`, and used it only for `one_to_many` api. We noticed that this class is kind of abandoned, some private members and methods are missing, interfaces of outer classes are changed etc..., we did what we can to "repair" this class and magically it seemed that it worked.

## **What we have got**

The test result shows, with `timedistancematrix`, valhalla responded 3 times faster, however we found result returned by `timedistancematrix` were tiny different from the result computed by `costmatrix`, in 99% of cases, it was like 1 second for time or 1 meter for distance. We guessed that it may be due to the rounding errors. In 1% of cases, the difference was much larger. The check showed the result returned by `timedistancematrix` was correct.

## **What we are going to do**
Is to profile `timedistancematrix` and optimise it as we can

## **What we want to hear from you**

Besides your advices on code, we'd like to have your advices on how we switch the implementation of `one_to_many`/`many_to_one`/`many_to_many` APIs(https://github.com/valhalla/thor/compare/master...xlqian:enable_distancematrix_for_one_to_many?expand=1#diff-5856bbf06ad9bac8e0872ebf32f229c2R128). By arguments in URL? By valhalla.json? Or both?
  
