### PR TITLE
Fix for costmatrix slowdown for one to many

### DIFF
--- a/src/thor/costmatrix.cc
+++ b/src/thor/costmatrix.cc
@@ -193,8 +193,18 @@ void CostMatrix::Initialize(
   }
 
   // Set the remaining number of sources and targets
-  remaining_sources_ = all_the_same ? 0 : source_count_;
-  remaining_targets_ = all_the_same ? 0 : target_count_;
+   remaining_sources_ = 0;
+   for (auto s : source_status_) {
+     if (!s.remaining_locations.empty()) {
+       remaining_sources_++;
+     }
+   }
+   remaining_targets_ = 0;
+   for (auto t : target_status_) {
+     if (!t.remaining_locations.empty()) {
+       remaining_targets_++;
+     }
+   }
 }
 
 // Iterate the forward search from the source/origin location.


### PR DESCRIPTION
CostMatrix is not properly terminating and is taking a longer than normal amount of time for one-to-many requests. This request should take very little time at all since the locations are very close together.

http://localhost:8002/one_to_many?json={%22locations%22:[{%22lat%22:40.744015,%22lon%22:-73.990509},{%22lat%22:40.739735,%22lon%22:-73.979713},{%22lat%22:40.752522,%22lon%22:-73.985016},{%22lat%22:40.750118,%22lon%22:-73.983704},{%22lat%22:40.750553,%22lon%22:-73.993523}]}&costing=auto
