### PR TITLE
Go back to using A* if any origin and destination edges are the same

### DIFF
--- a/src/thor/route_action.cc
+++ b/src/thor/route_action.cc
@@ -110,11 +110,6 @@ namespace valhalla {
         const baldr::PathLocation& origin, const baldr::PathLocation& destination) {
     if (routetype == "multimodal" || routetype == "transit") {
       return &multi_modal_astar;
-    } else if (routetype == "bus") {
-      // TODO - can we use bidirectional A*?
-      return &astar;
-    } else if (routetype == "pedestrian") {
-      return &bidir_astar;
     } else {
       // Use A* if any origin and destination edges are the same - otherwise
       // use bidirectional A*. Bidirectional A* does not handle trivial cases


### PR DESCRIPTION
This fixes issue #450  with through locations when there is only 1 edge in the path. Also, bus should use bidirectional A* as all others.