### PR TITLE
if a bus or rail line goes beyond the max, we need to consider transit options

### DIFF
--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -389,8 +389,7 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
   uint32_t max_transfer_distance = 99999.0f; //costing->GetMaxTransferDistanceMM();
 
   // Initialize and create the isotile
-  // add 5 minutes in case the transit trip is right on the edge.
-  auto max_seconds = (max_minutes * 60) + 300;
+  auto max_seconds = max_minutes * 60;
   Initialize(costing->UnitSize());
   ConstructIsoTile(true, max_minutes, origin_locations);
 

--- a/src/thor/isochrone.cc
+++ b/src/thor/isochrone.cc
@@ -389,7 +389,8 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
   uint32_t max_transfer_distance = 99999.0f; //costing->GetMaxTransferDistanceMM();
 
   // Initialize and create the isotile
-  auto max_seconds = max_minutes * 60;
+  // add 5 minutes in case the transit trip is right on the edge.
+  auto max_seconds = (max_minutes * 60) + 300;
   Initialize(costing->UnitSize());
   ConstructIsoTile(true, max_minutes, origin_locations);
 
@@ -452,12 +453,6 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
       continue;
     }
 
-    // Return after the time interval has been met
-    if (pred.cost().secs > max_seconds) {
-      LOG_INFO("Exceed time interval: n = " + std::to_string(n));
-      return isotile_;
-    }
-
     // Set local time. TODO: adjust for time zone.
     uint32_t localtime = start_time + pred.cost().secs;
 
@@ -511,7 +506,7 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
     uint32_t shortcuts = 0;
     GraphId edgeid(node.tileid(), node.level(), nodeinfo->edge_index());
     const DirectedEdge* directededge = tile->directededge(nodeinfo->edge_index());
-    for (uint32_t i = 0, n = nodeinfo->edge_count(); i < n;
+    for (uint32_t i = 0; i < nodeinfo->edge_count();
                 i++, directededge++, edgeid++) {
       // Skip shortcut edges
       if (directededge->is_shortcut()) {
@@ -538,7 +533,6 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
       // Reset cost and walking distance
       Cost newcost = pred.cost();
       uint32_t walking_distance = pred.path_distance();
-
       // If this is a transit edge - get the next departure. Do not check
       // if allowed by costing - assume if you get a transit edge you
       // walked to the transit stop
@@ -660,6 +654,13 @@ std::shared_ptr<const GriddedData<PointLL> > Isochrone::ComputeMultiModal(
       if (directededge->use() == Use::kTransitConnection &&
           pred.prior_stopid().Is_Valid() &&
           walking_distance > max_transfer_distance) {
+        continue;
+      }
+
+      // Continue if the time interval has been met...
+      // this bus or rail line goes beyond the max but need to consider others
+      // so we just continue here.
+      if (newcost.secs > max_seconds) {
         continue;
       }
 

--- a/src/thor/isochrone_action.cc
+++ b/src/thor/isochrone_action.cc
@@ -30,9 +30,13 @@ namespace valhalla {
       auto generalize = request.get<float>("generalize", .2f);
 
       //get the raster
+      //Extend the times in the 2-D grid to be 10 minutes beyond the highest contour time.
+      //Cost (including penalties) is used when adding to the adjacency list but the elapsed
+      //time in seconds is used when terminating the search. The + 10 minutes adds a buffer for edges
+      //where there has been a higher cost that might still be marked in the isochrone
       auto grid = (costing == "multimodal" || costing == "transit") ?
-        isochrone_gen.ComputeMultiModal(correlated, contours.back(), reader, mode_costing, mode) :
-        isochrone_gen.Compute(correlated, contours.back(), reader, mode_costing, mode);
+        isochrone_gen.ComputeMultiModal(correlated, contours.back()+10, reader, mode_costing, mode) :
+        isochrone_gen.Compute(correlated, contours.back()+10, reader, mode_costing, mode);
 
       //turn it into geojson
       auto isolines = grid->GenerateContours(contours, polygons, denoise, generalize);


### PR DESCRIPTION
fixed a bug where the isochrone was cut off if we took transit that was greater than the max_seconds.

before

![image](https://cloud.githubusercontent.com/assets/2676277/20444111/bdabc14c-ad9d-11e6-8421-cf557e60c555.png)


after

![image](https://cloud.githubusercontent.com/assets/2676277/20444015/5f52fe94-ad9d-11e6-8a72-480cc246e2e7.png)

issue reported by @meghanhade 