### PR TITLE
Revert "Pass custom map-matching parameters to meili"

### DIFF
--- a/src/thor/trace_attributes_action.cc
+++ b/src/thor/trace_attributes_action.cc
@@ -76,7 +76,6 @@ worker_t::result_t thor_worker_t::trace_attributes(
   parse_locations(request);
   parse_shape(request);
   parse_costing(request);
-  parse_trace_config(request);
   /*
    * A flag indicating whether the input shape is a GPS trace or exact points from a
    * prior route run against the Valhalla road network.  Knowing that the input is from

--- a/src/thor/trace_route_action.cc
+++ b/src/thor/trace_route_action.cc
@@ -37,7 +37,6 @@ worker_t::result_t thor_worker_t::trace_route(const boost::property_tree::ptree 
   parse_locations(request);
   parse_shape(request);
   parse_costing(request);
-  parse_trace_config(request);
   /*
    * A flag indicating whether the input shape is a GPS trace or exact points from a
    * prior route run against the Valhalla road network.  Knowing that the input is from
@@ -120,7 +119,7 @@ odin::TripPath thor_worker_t::map_match(const TripPathController& controller) {
   // Create a matcher
   std::shared_ptr<meili::MapMatcher> matcher;
   try {
-    matcher.reset(matcher_factory.Create(trace_config));
+    matcher.reset(matcher_factory.Create(config));
   } catch (const std::invalid_argument& ex) {
     //return jsonify_error({400, 499}, request_info, std::string(ex.what()));
     throw std::runtime_error(std::string(ex.what()));
@@ -128,9 +127,7 @@ odin::TripPath thor_worker_t::map_match(const TripPathController& controller) {
 
   std::vector<meili::Measurement> sequence;
   for (const auto& coord : shape) {
-    sequence.emplace_back(coord, 
-                          matcher->config().get<float>("gps_accuracy"), 
-                          matcher->config().get<float>("search_radius"));
+    sequence.emplace_back(coord, gps_accuracy, search_radius);
   }
 
   // Create the vector of matched path results

--- a/valhalla/thor/service.h
+++ b/valhalla/thor/service.h
@@ -78,7 +78,6 @@ class thor_worker_t {
 
   void parse_locations(const boost::property_tree::ptree& request);
   void parse_shape(const boost::property_tree::ptree& request);
-  void parse_trace_config(const boost::property_tree::ptree& request);
   std::string parse_costing(const boost::property_tree::ptree& request);
 
   prime_server::worker_t::result_t route(
@@ -120,7 +119,8 @@ class thor_worker_t {
   float long_request;
   boost::optional<int> date_time_type;
   valhalla::meili::MapMatcherFactory matcher_factory;
-  boost::property_tree::ptree trace_config;
+  float gps_accuracy;
+  float search_radius;
 };
 
 }


### PR DESCRIPTION
Reverts valhalla/thor#493

@ericrwolfe the previous PR requires that the request have `trace_options` in it. we need to use get optional so that its not always required to be in the request