### PR TITLE
abort path finding if client disconnects (or request times out)

### DIFF
--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -18,7 +18,7 @@ constexpr uint64_t kInitialEdgeLabelCount = 500000;
 
 // Default constructor
 AStarPathAlgorithm::AStarPathAlgorithm()
-    : mode_(TravelMode::kDrive),
+    : PathAlgorithm(), mode_(TravelMode::kDrive),
       travel_type_(0),
       adjacencylist_(nullptr),
       edgestatus_(nullptr),
@@ -135,6 +135,10 @@ std::vector<PathInfo> AStarPathAlgorithm::GetBestPath(PathLocation& origin,
                          // towards destination
   const GraphTile* tile;
   while (true) {
+    // Allow this process to be aborted
+    if(interrupt && (edgelabels_.size() % 5000) == 0)
+      (*interrupt)();
+
     // Get next element from adjacency list. Check that it is valid. An
     // invalid label indicates there are no edges that can be expanded.
     uint32_t predindex = adjacencylist_->pop();

--- a/src/thor/astar.cc
+++ b/src/thor/astar.cc
@@ -134,10 +134,13 @@ std::vector<PathInfo> AStarPathAlgorithm::GetBestPath(PathLocation& origin,
   uint32_t nc = 0;       // Count of iterations with no convergence
                          // towards destination
   const GraphTile* tile;
+  size_t total_labels = 0;
   while (true) {
     // Allow this process to be aborted
-    if(interrupt && (edgelabels_.size() % 5000) == 0)
+    size_t current_labels = edgelabels_.size();
+    if(interrupt && total_labels/kInterruptIterationsInterval < current_labels/kInterruptIterationsInterval)
       (*interrupt)();
+    total_labels = current_labels;
 
     // Get next element from adjacency list. Check that it is valid. An
     // invalid label indicates there are no edges that can be expanded.

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -25,7 +25,7 @@ namespace thor {
 constexpr uint64_t kInitialEdgeLabelCountBD = 1000000;
 
 // Default constructor
-BidirectionalAStar::BidirectionalAStar() {
+BidirectionalAStar::BidirectionalAStar(): PathAlgorithm() {
   threshold_ = 0;
   mode_ = TravelMode::kDrive;
   access_mode_ = kAutoAccess;
@@ -342,6 +342,10 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
   bool expand_forward  = true;
   bool expand_reverse  = true;
   while (true) {
+    // Allow this process to be aborted
+    if(interrupt && (edgelabels_forward_.size() + edgelabels_reverse_.size() % 5000) == 0)
+      (*interrupt)();
+
     // Get the next predecessor (based on which direction was
     // expanded in prior step)
     if (expand_forward) {

--- a/src/thor/bidirectional_astar.cc
+++ b/src/thor/bidirectional_astar.cc
@@ -341,10 +341,13 @@ std::vector<PathInfo> BidirectionalAStar::GetBestPath(PathLocation& origin,
   const GraphTile* tile2;
   bool expand_forward  = true;
   bool expand_reverse  = true;
+  size_t total_labels = 0;
   while (true) {
     // Allow this process to be aborted
-    if(interrupt && (edgelabels_forward_.size() + edgelabels_reverse_.size() % 5000) == 0)
+    size_t current_labels = edgelabels_forward_.size() + edgelabels_reverse_.size();
+    if(interrupt && total_labels/kInterruptIterationsInterval < current_labels/kInterruptIterationsInterval)
       (*interrupt)();
+    total_labels = current_labels;
 
     // Get the next predecessor (based on which direction was
     // expanded in prior step)

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -142,10 +142,13 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
   std::unordered_set<uint32_t> processed_tiles;
 
   const GraphTile* tile;
+  size_t total_labels = 0;
   while (true) {
     // Allow this process to be aborted
-    if(interrupt && (edgelabels_.size() % 5000) == 0)
+    size_t current_labels = edgelabels_.size();
+    if(interrupt && total_labels/kInterruptIterationsInterval < current_labels/kInterruptIterationsInterval)
       (*interrupt)();
+    total_labels = current_labels;
 
     // Get next element from adjacency list. Check that it is valid. An
     // invalid label indicates there are no edges that can be expanded.

--- a/src/thor/multimodal.cc
+++ b/src/thor/multimodal.cc
@@ -143,6 +143,10 @@ std::vector<PathInfo> MultiModalPathAlgorithm::GetBestPath(
 
   const GraphTile* tile;
   while (true) {
+    // Allow this process to be aborted
+    if(interrupt && (edgelabels_.size() % 5000) == 0)
+      (*interrupt)();
+
     // Get next element from adjacency list. Check that it is valid. An
     // invalid label indicates there are no edges that can be expanded.
     uint32_t predindex = adjacencylist_->pop();

--- a/src/thor/service.cc
+++ b/src/thor/service.cc
@@ -103,7 +103,7 @@ namespace valhalla {
       return result;
     }
 
-    worker_t::result_t thor_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t&) {
+    worker_t::result_t thor_worker_t::work(const std::list<zmq::message_t>& job, void* request_info, const worker_t::interrupt_function_t& interrupt) {
       //get time for start of request
       auto s = std::chrono::system_clock::now();
       auto& info = *static_cast<http_request_info_t*>(request_info);
@@ -128,6 +128,10 @@ namespace valhalla {
 
         // Initialize request - get the PathALgorithm to use
         ACTION_TYPE action = static_cast<ACTION_TYPE>(request.get<int>("action"));
+        // Allow the request to be aborted
+        astar.set_interrupt(&interrupt);
+        bidir_astar.set_interrupt(&interrupt);
+        multi_modal_astar.set_interrupt(&interrupt);
         //what action is it
         switch (action) {
           case ONE_TO_MANY:

--- a/src/thor/service.cc
+++ b/src/thor/service.cc
@@ -129,7 +129,6 @@ namespace valhalla {
         // Initialize request - get the PathALgorithm to use
         ACTION_TYPE action = static_cast<ACTION_TYPE>(request.get<int>("action"));
         // Allow the request to be aborted
-        interrupt();
         astar.set_interrupt(&interrupt);
         bidir_astar.set_interrupt(&interrupt);
         multi_modal_astar.set_interrupt(&interrupt);

--- a/src/thor/service.cc
+++ b/src/thor/service.cc
@@ -129,6 +129,7 @@ namespace valhalla {
         // Initialize request - get the PathALgorithm to use
         ACTION_TYPE action = static_cast<ACTION_TYPE>(request.get<int>("action"));
         // Allow the request to be aborted
+        interrupt();
         astar.set_interrupt(&interrupt);
         bidir_astar.set_interrupt(&interrupt);
         multi_modal_astar.set_interrupt(&interrupt);

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -18,6 +18,7 @@ namespace valhalla {
 namespace thor {
 
 constexpr uint32_t kBucketCount = 20000;
+constexpr size_t kInterruptIterationsInterval = 5000;
 
 /**
  * Pure virtual class defining the interface for PathAlgorithm - the algorithm

--- a/valhalla/thor/pathalgorithm.h
+++ b/valhalla/thor/pathalgorithm.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <utility>
 #include <memory>
+#include <functional>
 
 #include <valhalla/baldr/graphid.h>
 #include <valhalla/baldr/graphreader.h>
@@ -24,6 +25,11 @@ constexpr uint32_t kBucketCount = 20000;
  */
 class PathAlgorithm {
  public:
+  /**
+   * Constructor
+   */
+  PathAlgorithm():interrupt(nullptr) { }
+
   /**
    * Destructor
    */
@@ -49,6 +55,16 @@ class PathAlgorithm {
    * Clear the temporary information generated during path construction.
    */
   virtual void Clear() = 0;
+
+  /**
+   * Set a callback that will throw when the path computation should be aborted
+   *
+   * @param interrupt_callback  the function to periodically call to see if we should abort
+   */
+  void set_interrupt(const std::function<void ()>* interrupt_callback) { interrupt = interrupt_callback; }
+
+ protected:
+  const std::function<void()>* interrupt;
 };
 
 }


### PR DESCRIPTION
this uses the number of edge labels added as a metric for when to check if there is an interrupt waiting. in bidirectional astar it seemed that you could get more than one new label at a time so i couldnt use modulus to check it. i basically did that on all the algorithms just in case they were that way too (i figured they werent?)

also note that our code ends up catching the exception that the interrupt throws so we end up actually wasting a bit of time replying to the client. this wasnt supposed to happen but isnt a big deal at all. it can be fixed in the future.

@noblige @dnesbitt61 